### PR TITLE
Small changes for ports to not clash with the UI-backend and debugger.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,7 +18,16 @@ link:http://www.hawkular.org/docs/rest/rest-alerts-v2.html[Hawkular Alerting RES
 
 == Run
 
-See ``external`` module for instructions
+See ``external`` module for instructions.
+
+Basically (note, this currently requires Java 1.8):
+
+[source,shell script]
+----
+mvn install
+cd external
+mvn quarkus:dev
+----
 
 == License
 

--- a/external/pom.xml
+++ b/external/pom.xml
@@ -67,6 +67,10 @@
         <groupId>io.quarkus</groupId>
         <artifactId>quarkus-maven-plugin</artifactId>
         <version>${quarkus.version}</version>
+        <configuration>
+          <debug>5006</debug>
+          <suspend>false</suspend>
+        </configuration>
         <executions>
           <execution>
             <goals>

--- a/external/src/main/docker/Dockerfile.jvm
+++ b/external/src/main/docker/Dockerfile.jvm
@@ -15,7 +15,7 @@
 #
 ###
 FROM fabric8/java-alpine-openjdk8-jre
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Dquarkus.http.port=8080 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
 ENV AB_ENABLED=jmx_exporter
 COPY target/lib/* /deployments/lib/
 COPY target/*-runner.jar /deployments/app.jar

--- a/external/src/main/docker/Dockerfile.native
+++ b/external/src/main/docker/Dockerfile.native
@@ -19,4 +19,4 @@ WORKDIR /work/
 COPY target/*-runner /work/application
 RUN chmod 775 /work
 EXPOSE 8080
-CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
+CMD ["./application", "-Dquarkus.http.host=0.0.0.0", "-Dquarkus.http.port=8080"]

--- a/external/src/main/resources/application.properties
+++ b/external/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 # Configuration file
 # key = value
 
+# Http port
+quarkus.http.port=8083
+
 # For dev only
 kafka-streams.consumer.session.timeout.ms=250
 kafka-streams.consumer.heartbeat.interval.ms=200


### PR DESCRIPTION
The ui-frontend already uses ports 8080 and 5005. Use 8083 and 5006 instead, so that one can run both locally at the same time.

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>