### PR TITLE
CPOL-27 Run REST-interface integration tests

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,6 +1,6 @@
 name: Java CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,4 +1,4 @@
-name: Java CI
+name: Run with integration tests
 
 on: [push, pull_request]
 
@@ -21,4 +21,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn -B package --file pom.xml -Pitest -Dhawkular.data=target/hawkular.data
+      run: mvn -B clean install -Pitest -Dhawkular.data=target/hawkular.data

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,4 +21,4 @@ jobs:
       with:
         java-version: 1.8
     - name: Build with Maven
-      run: mvn -B package --file pom.xml
+      run: mvn -B package --file pom.xml -Pitest -Dhawkular.data=target/hawkular.data

--- a/api/src/main/java/org/hawkular/alerts/api/model/condition/EventCondition.java
+++ b/api/src/main/java/org/hawkular/alerts/api/model/condition/EventCondition.java
@@ -211,7 +211,7 @@ public class EventCondition extends Condition {
         if (isEmpty(expression) && isEmpty(expr)) {
             return true;
         }
-        if(expr != null) {
+        if(expr != null && !isEmpty(expr)) {
             // Process expr first
             return ExpressionParser.evaluateConditions(value.getFacts(), expr);
         }

--- a/api/src/test/java/org/hawkular/alerts/api/EventConditionTest.java
+++ b/api/src/test/java/org/hawkular/alerts/api/EventConditionTest.java
@@ -1,15 +1,14 @@
 package org.hawkular.alerts.api;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 import org.hawkular.alerts.api.model.condition.EventCondition;
 import org.hawkular.alerts.api.model.event.Event;
 import org.junit.Test;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Jay Shaughnessy
@@ -190,26 +189,5 @@ public class EventConditionTest {
                 "facts.server == 'MyServer', facts.insanity.mylife == 'gone', facts.this.could.go.deep == 'no'");
 
         assertFalse(condition2.match(event1));
-    }
-
-    @Test
-    public void testParsing() {
-        String first = "key";
-        String second = "key.anotherkey";
-        String third = "key.another.yetanother";
-        String fourth = "key.another.yetanother.still";
-
-        System.out.println(Arrays.toString(first.split("\\.", 2)));
-        System.out.println(Arrays.toString(second.split("\\.", 2)));
-        System.out.println(Arrays.toString(third.split("\\.", 2)));
-
-        String[] subMap = fourth.split("\\.", 2);
-
-        while(subMap.length > 1) {
-            subMap = subMap[1].split("\\.", 2);
-            System.out.printf("Checking key: %s\n", subMap[0]);
-        }
-
-        System.out.printf("Ending key: %s\n", subMap[0]);
     }
 }

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/AlertsEngineImpl.java
@@ -580,7 +580,7 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
                 TreeSet<Data> newData = getAndClearPendingData();
                 TreeSet<Event> newEvents = getAndClearPendingEvents();
 
-                log.infof("Executing rules engine on %s datums, %s events, %s dampening timeouts.", newData.size(),
+                log.debugf("Executing rules engine on %s datums, %s events, %s dampening timeouts.", newData.size(),
                         newEvents.size(), numTimeouts);
 
                 try {
@@ -620,6 +620,7 @@ public class AlertsEngineImpl implements AlertsEngine, PartitionTriggerListener,
                     log.debugf("Error on rules processing: %s", e);
                     log.errorProcessingRules(e.getMessage());
                 } finally {
+                    // TODO Is this thread safe?
                     alerts.clear();
                     events.clear();
                 }

--- a/engine/src/main/java/org/hawkular/alerts/engine/impl/DroolsRulesEngineImpl.java
+++ b/engine/src/main/java/org/hawkular/alerts/engine/impl/DroolsRulesEngineImpl.java
@@ -142,7 +142,7 @@ public class DroolsRulesEngineImpl implements RulesEngine {
         int fireCycle = 0;
         long startFiring = System.currentTimeMillis();
         while (!pendingData.isEmpty() || !pendingEvents.isEmpty()) {
-            log.infof("Firing rules... PendingData [%s] PendingEvents [%s]", initialPendingData,
+            log.debugf("Firing rules... PendingData [%s] PendingEvents [%s]", initialPendingData,
                     initialPendingEvents);
 
             batchData();
@@ -157,7 +157,7 @@ public class DroolsRulesEngineImpl implements RulesEngine {
             }
 
             for (Object object : kSession.getObjects()) {
-                log.infof("Object: %s", object);
+                log.debugf("Object: %s", object);
             }
 
             kSession.fireAllRules();

--- a/engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
+++ b/engine/src/main/resources/org/hawkular/alerts/engine/rules/ConditionMatch.drl
@@ -224,8 +224,8 @@ rule Event
         $d : Event( tenantId == $tenantId, dataSource == $tsource, dataId == $did )
     then
         EventConditionEval ce = new EventConditionEval($c, $d);
-        if (log != null) {
-            log.infof("Event Eval: %s %s", (ce.isMatch() ? "Match!" : "no match"), ce.getDisplayString());
+        if (log != null && log.isDebugEnabled()) {
+            log.debugf("Event Eval: %s %s", (ce.isMatch() ? "Match!" : "no match"), ce.getDisplayString());
         }
         insert( ce );
 end

--- a/engine/src/test/resources/hawkular-alerts.properties
+++ b/engine/src/test/resources/hawkular-alerts.properties
@@ -1,3 +1,0 @@
-# Internal configuration registration, used to provide default values
-hawkular-alerts.engine-delay=1000
-hawkular-alerts.engine-period=2000

--- a/external/pom.xml
+++ b/external/pom.xml
@@ -60,6 +60,13 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-vertx-web</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>org.codehaus.groovy.modules.http-builder</groupId>
+      <artifactId>http-builder</artifactId>
+      <version>${version.org.codehaus.groovy.modules.http-builder}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -144,8 +151,7 @@
               <dependency>
               <groupId>org.codehaus.groovy</groupId>
               <artifactId>groovy-all</artifactId>
-              <!-- any version of Groovy \>= 1.5.0 should work here -->
-              <version>2.4.10</version>
+                <version>${version.org.codehaus.groovy}</version>
               <scope>runtime</scope>
               <type>pom</type>
               </dependency>
@@ -169,6 +175,41 @@
                 </goals>
               </execution>
             </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+    <id>itest</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.gmavenplus</groupId>
+            <artifactId>gmavenplus-plugin</artifactId>
+            <version>${version.org.codehaus.gmavenplus}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>addSources</goal>
+                  <goal>addTestSources</goal>
+                  <goal>generateStubs</goal>
+                  <goal>compile</goal>
+                  <goal>generateTestStubs</goal>
+                  <goal>compileTests</goal>
+                  <goal>removeStubs</goal>
+                  <goal>removeTestStubs</goal>
+                </goals>
+              </execution>
+            </executions>
+            <dependencies>
+              <dependency>
+                <groupId>org.codehaus.groovy</groupId>
+                <artifactId>groovy-all</artifactId>
+                <version>${version.org.codehaus.groovy}</version>
+                <scope>runtime</scope>
+                <type>pom</type>
+              </dependency>
+            </dependencies>
           </plugin>
         </plugins>
       </build>

--- a/external/src/main/java/com/redhat/cloud/custompolicies/engine/actions/plugins/EmailActionPluginListener.java
+++ b/external/src/main/java/com/redhat/cloud/custompolicies/engine/actions/plugins/EmailActionPluginListener.java
@@ -45,6 +45,7 @@ public class EmailActionPluginListener implements ActionPluginListener {
         Set<String> properties = new HashSet<>();
         properties.add("from");
         properties.add("to");
+        properties.add("cc");
         return properties;
     }
 

--- a/external/src/main/java/com/redhat/cloud/custompolicies/engine/handlers/EventsHandler.java
+++ b/external/src/main/java/com/redhat/cloud/custompolicies/engine/handlers/EventsHandler.java
@@ -82,8 +82,6 @@ public class EventsHandler {
 
     @PostConstruct
     public void init(@Observes Router router) {
-        log.info("init PostConstruct was called");
-//    public void initRoutes(String baseUrl, Router router) {
         String path = "/hawkular/alerts/events";
         router.route().handler(BodyHandler.create());
         router.post(path).handler(this::createEvent);
@@ -120,8 +118,6 @@ public class EventsHandler {
                     try {
                         event = fromJson(json, Event.class);
                     } catch (Exception e) {
-//                        // log.errorf"Error parsing Event json: %s. Reason: %s", json, e.toString());
-                        e.printStackTrace();
                         throw new ResponseUtil.BadRequestException(e.toString());
                     }
                     if (event == null) {
@@ -150,10 +146,7 @@ public class EventsHandler {
                         throw new ResponseUtil.BadRequestException("Event with ID [" + event.getId() + "] exists.");
                     }
 
-                    System.out.println("Event: "+ event.toString());
-
                     try {
-                        System.out.println("Storing to: " + alertsService.toString());
                         alertsService.addEvents(Collections.singletonList(event));
                         future.complete(event);
                     } catch (IllegalArgumentException e) {
@@ -196,7 +189,6 @@ public class EventsHandler {
                     }
                     try {
                         events.stream().forEach(ev -> ev.setTenantId(tenantId));
-                        System.out.println("Events: "+ events.toString());
                         alertsService.sendEvents(events);
                         // log.debugf(Events: ", events);
                         future.complete(events);

--- a/external/src/main/java/com/redhat/cloud/custompolicies/engine/handlers/ImportHandler.java
+++ b/external/src/main/java/com/redhat/cloud/custompolicies/engine/handlers/ImportHandler.java
@@ -1,0 +1,115 @@
+package com.redhat.cloud.custompolicies.engine.handlers;
+
+import com.redhat.cloud.custompolicies.engine.handlers.util.ResponseUtil;
+import io.vertx.ext.web.Router;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.handler.BodyHandler;
+import org.apache.kafka.common.requests.ApiError;
+import org.hawkular.alerts.api.doc.*;
+import org.hawkular.alerts.api.model.export.Definitions;
+import org.hawkular.alerts.api.model.export.ImportType;
+import org.hawkular.alerts.api.services.DefinitionsService;
+import org.hawkular.commons.log.MsgLogger;
+import org.hawkular.commons.log.MsgLogging;
+
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.event.Observes;
+import javax.inject.Inject;
+
+import static org.hawkular.alerts.api.doc.DocConstants.POST;
+import static org.hawkular.alerts.api.json.JsonUtil.fromJson;
+
+/**
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@ApplicationScoped
+@DocEndpoint(value = "/import", description = "Import of triggers and actions definitions")
+public class ImportHandler {
+    private static final MsgLogger log = MsgLogging.getMsgLogger(ImportHandler.class);
+
+    @Inject
+    DefinitionsService definitionsService;
+
+    @PostConstruct
+    public void init(@Observes Router router) {
+        String path = "/hawkular/alerts/import";
+        router.route().handler(BodyHandler.create());
+        router.post(path + "/:strategy").handler(this::importDefinitions);
+    }
+
+    @DocPath(method = POST,
+            path = "/{strategy}",
+            name = "Import a list of full triggers and action definitions.",
+            notes = "Return a list of effectively imported full triggers and action definitions. + \n" +
+                    " + \n" +
+                    "Import options: + \n" +
+                    " + \n" +
+                    "DELETE + \n" +
+                    "" +
+                    " + \n" +
+                    "Existing data in the backend is DELETED before the import operation. + \n" +
+                    "All <<FullTrigger>> and <<ActionDefinition>> objects defined in the <<Definitions>> parameter " +
+                    "are imported. + \n" +
+                    " + \n" +
+                    "ALL + \n" +
+                    " + \n" +
+                    "Existing data in the backend is NOT DELETED before the import operation. + \n" +
+                    "All <<FullTrigger>> and <<ActionDefinition>> objects defined in the <<Definitions>> parameter " +
+                    "are imported. + \n" +
+                    "Existing <<FullTrigger>> and <<ActionDefinition>> objects are overwritten with new values " +
+                    "passed in the <<Definitions>> parameter." +
+                    " + \n" +
+                    "NEW + \n" +
+                    " + \n" +
+                    "Existing data in the backend is NOT DELETED before the import operation. + \n" +
+                    "Only NEW <<FullTrigger>> and <<ActionDefinition>> objects defined in the <<Definitions>> " +
+                    "parameters are imported. + \n" +
+                    "Existing <<FullTrigger>> and <<ActionDefinition>> objects are maintained in the backend. + \n" +
+                    " + \n" +
+                    "OLD + \n" +
+                    "Existing data in the backend is NOT DELETED before the import operation. + \n" +
+                    "Only <<FullTrigger>> and <<ActionDefinition>> objects defined in the <<Definitions>> parameter " +
+                    "that previously exist in the backend are imported and overwritten. + \n" +
+                    "New <<FullTrigger>> and <<ActionDefinition>> objects that don't exist previously in the " +
+                    "backend are ignored. + \n" +
+                    " + \n")
+    @DocParameters(value = {
+            @DocParameter(name = "strategy", required = true, path = true,
+                    description = "Import strategy.",
+                    allowableValues = "DELETE,ALL,NEW,OLD"),
+            @DocParameter(required = true, body = true, type = Definitions.class,
+                    description = "Collection of full triggers and action definitions to import.")
+    })
+    @DocResponses(value = {
+            @DocResponse(code = 200, message = "Successfully exported list of full triggers and action definitions.", response = Definitions.class),
+            @DocResponse(code = 400, message = "Bad Request/Invalid Parameters.", response = ApiError.class),
+            @DocResponse(code = 500, message = "Internal server error.", response = ApiError.class)
+    })
+    public void importDefinitions(RoutingContext routing) {
+        routing.vertx()
+                .executeBlocking(future -> {
+                    String tenantId = ResponseUtil.checkTenant(routing);
+                    String json = routing.getBodyAsString();
+                    String strategy = routing.request().getParam("strategy");
+                    Definitions definitions;
+                    try {
+                        definitions = fromJson(json, Definitions.class);
+                    } catch (Exception e) {
+                        log.errorf("Error parsing Definitions json: %s. Reason: %s", json, e.toString());
+                        throw new ResponseUtil.NotFoundException(e.toString());
+                    }
+                    try {
+                        ImportType importType = ImportType.valueOf(strategy.toUpperCase());
+                        Definitions imported = definitionsService.importDefinitions(tenantId, definitions, importType);
+                        future.complete(imported);
+                    } catch (IllegalArgumentException e) {
+                        throw new ResponseUtil.BadRequestException(e.toString());
+                    } catch (Exception e) {
+                        log.debug(e.getMessage(), e);
+                        throw new ResponseUtil.InternalServerException(e.toString());
+                    }
+                }, res -> ResponseUtil.result(routing, res));
+    }
+}

--- a/external/src/test/groovy/org/hawkular/alerts/rest/AbstractQuarkusITestBase.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/AbstractQuarkusITestBase.groovy
@@ -1,0 +1,54 @@
+package org.hawkular.alerts.rest
+
+import groovyx.net.http.ContentType
+import groovyx.net.http.RESTClient
+import org.junit.jupiter.api.BeforeAll
+
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Base class for REST tests.
+ *
+ * @author Lucas Ponce
+ */
+abstract class AbstractQuarkusITestBase {
+
+    static baseURI = 'http://127.0.0.1:8081/hawkular/alerts/'
+    static RESTClient client
+    static String tenantHeaderName = "Hawkular-Tenant"
+    static final String TENANT_PREFIX = UUID.randomUUID().toString()
+    static final AtomicInteger TENANT_ID_COUNTER = new AtomicInteger(0)
+    static cluster = System.getProperty('cluster') ? true : false
+    static testTenant = nextTenantId()
+
+    static String failureEntity;
+
+    @BeforeAll
+    static void initClient() {
+
+        client = new RESTClient(baseURI, ContentType.JSON)
+        // this prevents 404 from being wrapped in an Exception, just return the response, better for testing
+        client.handler.failure = { resp ->
+          failureEntity = null
+          if (resp.entity != null && resp.entity.contentLength != 0) {
+            def baos = new ByteArrayOutputStream()
+            resp.entity.writeTo(baos)
+            failureEntity = new String(baos.toByteArray(), "UTF-8")
+          }
+          return resp
+        }
+
+        client.headers.put("Hawkular-Tenant", testTenant)
+    }
+
+    static String nextTenantId() {
+        return "T${TENANT_PREFIX}${TENANT_ID_COUNTER.incrementAndGet()}"
+    }
+
+//    static void waitDefinitions() {
+//        Thread.sleep(100)
+//        if (cluster) {
+//            Thread.sleep(500);
+//        }
+//    }
+}

--- a/external/src/test/groovy/org/hawkular/alerts/rest/AbstractQuarkusITestBase.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/AbstractQuarkusITestBase.groovy
@@ -45,10 +45,7 @@ abstract class AbstractQuarkusITestBase {
         return "T${TENANT_PREFIX}${TENANT_ID_COUNTER.incrementAndGet()}"
     }
 
-//    static void waitDefinitions() {
-//        Thread.sleep(100)
-//        if (cluster) {
-//            Thread.sleep(500);
-//        }
-//    }
+    static void waitDefinitions() {
+        Thread.sleep(100)
+    }
 }

--- a/external/src/test/groovy/org/hawkular/alerts/rest/ActionsITest.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/ActionsITest.groovy
@@ -1,0 +1,634 @@
+package org.hawkular.alerts.rest
+
+import io.quarkus.test.junit.QuarkusTest
+import org.hawkular.alerts.api.model.action.ActionDefinition
+import org.hawkular.alerts.api.model.condition.AvailabilityCondition
+import org.hawkular.alerts.api.model.condition.Condition
+import org.hawkular.alerts.api.model.condition.ThresholdCondition
+import org.hawkular.alerts.api.model.data.Data
+import org.hawkular.alerts.api.model.trigger.Mode
+import org.hawkular.alerts.api.model.trigger.Trigger
+import org.hawkular.alerts.api.model.trigger.TriggerAction
+import org.hawkular.commons.log.MsgLogger
+import org.hawkular.commons.log.MsgLogging
+import org.junit.jupiter.api.Test
+
+import static org.hawkular.alerts.api.model.event.Alert.Status
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+/**
+ * Actions REST tests.
+ *
+ * @author Lucas Ponce
+ */
+@QuarkusTest
+class ActionsITest extends AbstractQuarkusITestBase {
+
+    static MsgLogger logger = MsgLogging.getMsgLogger(ActionsITest.class)
+
+    @Test
+    void findSupportedPlugins() {
+        // Email plugin and webhook plugin should be installed by default
+        def resp = client.get(path: "plugins")
+        def data = resp.data
+        assertEquals(200, resp.status)
+        assertTrue(data.size() == 2)
+        assertThat(resp.data, containsInAnyOrder("email", "webhook"))
+    }
+
+//    @Test
+//    void findSupportedPlugins() {
+//        def resp =client.get(path: "plugins/email")
+//        assertEquals(200, resp.status)
+//    }
+
+    @Test
+    void createAction() {
+        String actionPlugin = "email"
+        String actionId = "test-action";
+
+        Map<String, String> actionProperties = new HashMap<>();
+        actionProperties.put("from", "from-email@company.org");
+        actionProperties.put("to", "to-email@company.org");
+        actionProperties.put("cc", "cc-email@company.org");
+
+        ActionDefinition actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+
+        def resp = client.post(path: "actions", body: actionDefinition)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "actions/" + actionPlugin + "/" + actionId);
+        assertEquals(200, resp.status)
+        assertEquals("from-email@company.org", resp.data.properties.from)
+
+        actionDefinition.getProperties().put("cc", "cc-modified@company.org")
+        resp = client.put(path: "actions", body: actionDefinition)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "actions/" + actionPlugin + "/" + actionId)
+        assertEquals(200, resp.status)
+        assertEquals("cc-modified@company.org", resp.data.properties.cc)
+
+        resp = client.delete(path: "actions/" + actionPlugin + "/" + actionId)
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void createComplexAction() {
+        String actionPlugin = "email"
+        String actionId = "test-action";
+
+        Map<String, String> actionProperties = new HashMap<>();
+        actionProperties.put("from", "from-default@company.org");
+        actionProperties.put("from.resolved", "from-resolved@company.org");
+        actionProperties.put("from.acknowledged", "from-acknowledged@company.org");
+        actionProperties.put("to", "to-default@company.org");
+        actionProperties.put("to.acknowledged", "to-acknowledged@company.org");
+        actionProperties.put("cc", "cc-email@company.org");
+
+        ActionDefinition actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+
+        def resp = client.post(path: "actions", body: actionDefinition)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "actions/" + actionPlugin + "/" + actionId);
+        assertEquals(200, resp.status)
+        assertEquals("from-default@company.org", resp.data.properties["from"])
+        assertEquals("from-resolved@company.org", resp.data.properties["from.resolved"])
+        assertEquals("from-acknowledged@company.org", resp.data.properties["from.acknowledged"])
+
+        actionDefinition.getProperties().put("cc", "cc-modified@company.org")
+        resp = client.put(path: "actions", body: actionDefinition)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "actions/" + actionPlugin + "/" + actionId)
+        assertEquals(200, resp.status)
+        assertEquals("cc-modified@company.org", resp.data.properties.cc)
+
+        resp = client.delete(path: "actions/" + actionPlugin + "/" + actionId)
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void failWithUnknownPropertyOnPlugin() {
+        // CREATE the action definition
+        String actionPlugin = "email"
+        String actionId = "email-to-admin";
+
+        Map<String, String> actionProperties = new HashMap<>();
+        actionProperties.put("from", "from-alerts@company.org");
+        actionProperties.put("to", "to-admin@company.org");
+        actionProperties.put("cc", "cc-developers@company.org");
+        actionProperties.put("bad-property", "cc-developers@company.org");
+
+        ActionDefinition actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+
+        def resp = client.post(path: "actions", body: actionDefinition)
+        assert(400 == resp.status)
+    }
+
+    @Test
+    void availabilityTest() {
+        String start = String.valueOf(System.currentTimeMillis());
+
+        // CREATE the action definition
+        String actionPlugin = "email"
+        String actionId = "email-to-admin";
+
+        Map<String, String> actionProperties = new HashMap<>();
+        actionProperties.put("from", "from-alerts@company.org");
+        actionProperties.put("to", "to-admin@company.org");
+        actionProperties.put("cc", "cc-developers@company.org");
+
+        ActionDefinition actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+
+        def resp = client.post(path: "actions", body: actionDefinition)
+        assert(200 == resp.status || 400 == resp.status)
+
+        // CREATE the trigger
+        resp = client.get(path: "")
+        assert resp.status == 200 : resp.status
+
+        Trigger testTrigger = new Trigger("test-email-availability", "http://www.mydemourl.com");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/test-email-availability")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setAutoDisable(false);
+        testTrigger.setAutoResolve(false);
+        testTrigger.setAutoResolveAlerts(false);
+        /*
+            email-to-admin action is pre-created from demo data
+         */
+        testTrigger.addAction(new TriggerAction("email", "email-to-admin"));
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing condition
+        AvailabilityCondition firingCond = new AvailabilityCondition("test-email-availability",
+                Mode.FIRING, "test-email-availability", AvailabilityCondition.Operator.NOT_UP);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+        resp = client.put(path: "triggers/test-email-availability/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        testTrigger.setEnabled(true);
+
+        resp = client.put(path: "triggers/test-email-availability", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-email-availability");
+        assertEquals(200, resp.status)
+        assertEquals("http://www.mydemourl.com", resp.data.name)
+        assertEquals(true, resp.data.enabled)
+        assertEquals(false, resp.data.autoDisable);
+        assertEquals(false, resp.data.autoResolve);
+        assertEquals(false, resp.data.autoResolveAlerts);
+
+        // FETCH recent alerts for trigger, should not be any
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-email-availability"] )
+        assertEquals(200, resp.status)
+
+        waitDefinitions()
+
+        // Send in DOWN avail data to fire the trigger
+        // Instead of going through the bus, in this test we'll use the alerts rest API directly to send data
+        for (int i=0; i<5; i++) {
+            Data avail = new Data("test-email-availability", System.currentTimeMillis() + (i*1000), "DOWN");
+            Collection<Data> datums = new ArrayList<>();
+            datums.add(avail);
+            resp = client.post(path: "data", body: datums);
+            assertEquals(200, resp.status)
+        }
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 10; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 5
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-email-availability"] )
+            if ( resp.status == 200 && resp.data.size() == 5 ) {
+                break;
+            }
+        }
+        assertEquals(200, resp.status)
+        assertEquals(5, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+
+        resp = client.delete(path: "triggers/test-email-availability");
+        assertEquals(200, resp.status)
+
+        resp = client.delete(path: "actions/" + actionPlugin + "/" + actionId)
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void thresholdTest() {
+        String start = String.valueOf(System.currentTimeMillis());
+
+        // CREATE the action definition
+        String actionPlugin = "email"
+        String actionId = "email-to-admin";
+
+        Map<String, String> actionProperties = new HashMap<>();
+        actionProperties.put("from", "from-alerts@company.org");
+        actionProperties.put("to", "to-admin@company.org");
+        actionProperties.put("cc", "cc-developers@company.org");
+
+        ActionDefinition actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+
+        def resp = client.post(path: "actions", body: actionDefinition)
+        assert(200 == resp.status || 400 == resp.status)
+
+        // CREATE the trigger
+        resp = client.get(path: "")
+        assert resp.status == 200 : resp.status
+
+        Trigger testTrigger = new Trigger("test-email-threshold", "http://www.mydemourl.com");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/test-email-threshold")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setAutoDisable(false);
+        testTrigger.setAutoResolve(false);
+        testTrigger.setAutoResolveAlerts(false);
+        /*
+            email-to-admin action is pre-created from demo data
+         */
+        testTrigger.addAction(new TriggerAction("email", "email-to-admin"));
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing condition
+        ThresholdCondition firingCond = new ThresholdCondition("test-email-threshold",
+                Mode.FIRING, "test-email-threshold", ThresholdCondition.Operator.GT, 300);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+        resp = client.put(path: "triggers/test-email-threshold/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        resp = client.put(path: "triggers/enabled", query:[triggerIds:"test-email-threshold",enabled:true] )
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-email-threshold");
+        assertEquals(200, resp.status)
+        assertEquals("http://www.mydemourl.com", resp.data.name)
+        assertEquals(true, resp.data.enabled)
+        assertEquals(false, resp.data.autoDisable);
+        assertEquals(false, resp.data.autoResolve);
+        assertEquals(false, resp.data.autoResolveAlerts);
+
+        // FETCH recent alerts for trigger, should not be any
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-email-threshold"] )
+        assertEquals(200, resp.status)
+
+        waitDefinitions()
+
+        // Send in data to fire the trigger
+        // Instead of going through the bus, in this test we'll use the alerts rest API directly to send data
+        for (int i=0; i<5; i++) {
+            Data threshold = new Data("test-email-threshold", System.currentTimeMillis() + (i*1000), String.valueOf(305.5 + i));
+            Collection<Data> datums = new ArrayList<>();
+            datums.add(threshold);
+            resp = client.post(path: "data", body: datums);
+            assertEquals(200, resp.status)
+        }
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 10; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 5
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-email-threshold"] )
+            if ( resp.status == 200 && resp.data.size() == 5 ) {
+                break;
+            }
+        }
+        assertEquals(200, resp.status)
+        assertEquals(5, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+
+        resp = client.delete(path: "triggers/test-email-threshold");
+        assertEquals(200, resp.status)
+
+        resp = client.delete(path: "actions/" + actionPlugin + "/" + actionId)
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void actionByStatusTest() {
+        String start = String.valueOf(System.currentTimeMillis());
+
+        // Check endpoint
+        def resp = client.get(path: "")
+        assert resp.status == 200 : resp.status
+
+        // Create an action definition for admins
+        String actionPlugin = "email"
+        String actionId = "notify-to-admins";
+
+        // Remove previous history
+        client.put(path: "actions/history/delete", query: [actionPlugins:"email"])
+
+        // Remove a previous action
+        client.delete(path: "actions/" + actionPlugin + "/" + actionId)
+
+        Map<String, String> actionProperties = new HashMap<>();
+        actionProperties.put("from", "from-alerts@company.org");
+        actionProperties.put("to", "to-admin@company.org");
+
+        ActionDefinition actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+
+        resp = client.post(path: "actions", body: actionDefinition)
+        assertEquals(200, resp.status)
+
+        // Create an action definition for developers
+        actionPlugin = "email"
+        actionId = "notify-to-developers";
+
+        // Remove a previous action
+        client.delete(path: "actions/" + actionPlugin + "/" + actionId)
+
+        actionProperties = new HashMap<>();
+        actionProperties.put("from", "from-alerts@company.org");
+        actionProperties.put("to", "to-developers@company.org");
+
+        actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+
+        resp = client.post(path: "actions", body: actionDefinition)
+        assertEquals(200, resp.status)
+
+        // Create a trigger
+
+        Trigger testTrigger = new Trigger("test-status-threshold", "http://www.mydemourl.com");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/test-status-threshold")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setAutoDisable(false);
+        testTrigger.setAutoResolve(false);
+        testTrigger.setAutoResolveAlerts(false);
+
+        TriggerAction notifyAdmins = new TriggerAction("email", "notify-to-admins");
+        notifyAdmins.addState(Status.OPEN.name());
+        TriggerAction notifyDevelopers = new TriggerAction("email", "notify-to-developers");
+        notifyDevelopers.addState(Status.ACKNOWLEDGED.name());
+
+        testTrigger.addAction(notifyAdmins);
+        testTrigger.addAction(notifyDevelopers);
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing condition
+        ThresholdCondition firingCond = new ThresholdCondition("test-status-threshold",
+                Mode.FIRING, "test-status-threshold", ThresholdCondition.Operator.GT, 300);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+        resp = client.put(path: "triggers/test-status-threshold/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-status-threshold",enabled:true] )
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-status-threshold");
+        assertEquals(200, resp.status)
+        assertEquals("http://www.mydemourl.com", resp.data.name)
+        assertEquals(true, resp.data.enabled)
+        assertEquals(false, resp.data.autoDisable);
+        assertEquals(false, resp.data.autoResolve);
+        assertEquals(false, resp.data.autoResolveAlerts);
+
+        waitDefinitions()
+
+        // Send in data to fire the trigger
+        // Instead of going through the bus, in this test we'll use the alerts rest API directly to send data
+        for (int i=0; i<5; i++) {
+            Data threshold = new Data("test-status-threshold", System.currentTimeMillis() + (i*1000), String.valueOf(305.5 + i));
+            Collection<Data> datums = new ArrayList<>();
+            datums.add(threshold);
+            resp = client.post(path: "data", body: datums);
+            assertEquals(200, resp.status)
+        }
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 100; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 5
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-status-threshold"] )
+            if ( resp.status == 200 && resp.data.size() == 5 ) {
+                break;
+            }
+        }
+        assertEquals(200, resp.status)
+        assertEquals(5, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+
+        def alertsToAck = resp.data;
+
+        // Check actions generated
+        // This used to fail randomly, therefore try several times before failing
+        for ( int i=0; i < 20; ++i ) {
+            resp = client.get(path: "actions/history", query: [startTime:start,actionPlugins:"email"])
+            if ( resp.status == 200 && resp.data.size() == 5 ) {
+                break;
+            }
+            Thread.sleep(500);
+        }
+        assertEquals(200, resp.status)
+        assertEquals(5, resp.data.size())
+
+        // Ack alerts generated
+        def alertsToAckIds = "";
+        for ( int i=0; i < alertsToAck.size(); i++ ) {
+            alertsToAckIds += alertsToAck[i].id;
+            if (i != 4) {
+                alertsToAckIds += ",";
+            }
+        }
+
+        // ACK Alerts generated
+        client.put(path: "ack", query: [alertIds:alertsToAckIds,ackBy:"testUser",ackNotes:"testNotes"] )
+
+        // Check if we have the actions for ACKNOWLEDGE
+        for ( int i=0; i < 10; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 5
+            resp = client.get(path: "actions/history", query: [startTime:start,actionPlugins:"email"])
+            if ( resp.status == 200 && resp.data.size() == 10 ) {
+                break;
+            }
+        }
+
+        assertEquals(200, resp.status)
+        assertEquals(10, resp.data.size())
+
+        resp = client.delete(path: "triggers/test-status-threshold");
+        assertEquals(200, resp.status)
+
+        resp = client.delete(path: "actions/email/notify-to-admins")
+        assertEquals(200, resp.status)
+
+        resp = client.delete(path: "actions/email/notify-to-developers")
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void globalActionsTest() {
+        String start = String.valueOf(System.currentTimeMillis());
+
+        // Check endpoint
+        def resp = client.get(path: "")
+        assert resp.status == 200 : resp.status
+
+        // Create an action definition for admins
+        String actionPlugin = "email"
+        String actionId = "global-action-notify-to-admins";
+
+        // Remove previous history
+        client.put(path: "actions/history/delete", query: [actionPlugins:"email"])
+
+        // Remove a previous action
+        client.delete(path: "actions/" + actionPlugin + "/" + actionId)
+
+        Map<String, String> actionProperties = new HashMap<>();
+        actionProperties.put("from", "from-alerts@company.org");
+        actionProperties.put("to", "to-admin@company.org");
+
+        ActionDefinition actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+        actionDefinition.setGlobal(true);
+
+        resp = client.post(path: "actions", body: actionDefinition)
+        assertEquals(200, resp.status)
+
+        // Create an action definition for developers
+        actionPlugin = "email"
+        actionId = "global-action-notify-to-developers";
+
+        // Remove a previous action
+        client.delete(path: "actions/" + actionPlugin + "/" + actionId)
+
+        actionProperties = new HashMap<>();
+        actionProperties.put("from", "from-alerts@company.org");
+        actionProperties.put("to", "to-developers@company.org");
+
+        actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+        actionDefinition.setGlobal(true);
+
+        resp = client.post(path: "actions", body: actionDefinition)
+        assertEquals(200, resp.status)
+
+        // Create a trigger
+
+        Trigger testTrigger = new Trigger("test-global-status-threshold", "http://www.mydemourl.com");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/test-global-status-threshold")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setAutoDisable(false);
+        testTrigger.setAutoResolve(false);
+        testTrigger.setAutoResolveAlerts(false);
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing condition
+        ThresholdCondition firingCond = new ThresholdCondition("test-global-status-threshold",
+                Mode.FIRING, "test-global-status-threshold", ThresholdCondition.Operator.GT, 300);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+        resp = client.put(path: "triggers/test-global-status-threshold/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        resp = client.put(path: "triggers/enabled", query:[triggerIds:"test-global-status-threshold",enabled:true] )
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-global-status-threshold");
+        assertEquals(200, resp.status)
+        assertEquals("http://www.mydemourl.com", resp.data.name)
+        assertEquals(true, resp.data.enabled)
+        assertEquals(false, resp.data.autoDisable);
+        assertEquals(false, resp.data.autoResolve);
+        assertEquals(false, resp.data.autoResolveAlerts);
+
+        waitDefinitions()
+
+        // Send in data to fire the trigger
+        // Instead of going through the bus, in this test we'll use the alerts rest API directly to send data
+        for (int i=0; i<5; i++) {
+            Data threshold = new Data("test-global-status-threshold", System.currentTimeMillis() + (i*1000),
+                    String.valueOf(305.5 + i));
+            Collection<Data> datums = new ArrayList<>();
+            datums.add(threshold);
+            resp = client.post(path: "data", body: datums);
+            assertEquals(200, resp.status)
+        }
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 100; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 5
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-global-status-threshold"] )
+            if ( resp.status == 200 && resp.data.size() == 5 ) {
+                break;
+            }
+        }
+        assertEquals(200, resp.status)
+        assertEquals(5, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+
+        // Check actions generated
+        // This used to fail randomly, therefore try several times before failing
+        for ( int i=0; i < 30; ++i ) {
+            resp = client.get(path: "actions/history",
+                    query: [startTime:start,actionPlugins:"email",
+                            actionIds:"global-action-notify-to-admins,global-action-notify-to-developers"])
+            if ( resp.status == 200 && resp.data.size() == 10 ) {
+                break;
+            }
+            Thread.sleep(500);
+        }
+
+        assertEquals(200, resp.status)
+        assertEquals(10, resp.data.size())
+
+        resp = client.delete(path: "triggers/test-global-status-threshold");
+        assertEquals(200, resp.status)
+
+        resp = client.delete(path: "actions/email/global-action-notify-to-admins")
+        assertEquals(200, resp.status)
+
+        resp = client.delete(path: "actions/email/global-action-notify-to-developers")
+        assertEquals(200, resp.status)
+    }
+}

--- a/external/src/test/groovy/org/hawkular/alerts/rest/AlertsITest.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/AlertsITest.groovy
@@ -1,0 +1,108 @@
+package org.hawkular.alerts.rest
+
+import io.quarkus.test.junit.QuarkusTest
+import org.junit.jupiter.api.Test
+
+/**
+ * Alerts REST tests.
+ *
+ * @author Lucas Ponce
+ */
+@QuarkusTest
+class AlertsITest extends AbstractQuarkusITestBase {
+
+    @Test
+    void findAlerts() {
+        def resp = client.get(path: "")
+        assert resp.status == 200 : resp.status
+    }
+
+    @Test
+    void findAlertsByCriteria() {
+        String now = String.valueOf(System.currentTimeMillis());
+        def resp = client.get(path: "", query: [endTime:now, startTime:"0",triggerIds:"Trigger-01,Trigger-02"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.get(path: "", query: [endTime:now, startTime:"0",alertIds:"Trigger-01|"+now+","+"Trigger-02|"+now] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.get(path: "", query: [endTime:now, startTime:"0",statuses:"OPEN,ACKNOWLEDGED,RESOLVED"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.get(path: "", query: [tags:"data-01|*,data-02|*"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.get(path: "", query: [tags:"dataId|data-01,dataId|data-02",thin:true] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.get(path: "", query: [tagQuery:"tagA or (tagB and tagC in ['e.*', 'f.*'])"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.get(path: "", query: [endResolvedTime:now, startResolvedTime:"0"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.get(path: "", query: [endAckTime:now, startAckTime:"0"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.get(path: "", query: [endStatusTime:now, startStatusTime:"0"] )
+        assert resp.status == 200 : resp.status
+    }
+
+    @Test
+    void findAlertsUnknownParams() {
+        String now = String.valueOf(System.currentTimeMillis());
+        def resp = client.get(path: "", query: [
+            startTime:"0", endTime:now,
+            startAckTime:"0", endAckTime:now,
+            startResolvedTime:"0", endResolvedTime:now,
+            alertIds:"Alert-01", triggerIds:"Trigger-01,Trigger-02", statuses: "OPEN", severities: "LOW",
+            tags: "a|b", tagQuery: "foo", thin: true] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.get(path: "", query: [
+            startyTime:"0", endTime:now,
+            alertIds:"Alert-01", triggrIds:"Trigger-01,Trigger-02", statuses: "OPEN"])
+        assert resp.status == 400 : resp.status
+        assert failureEntity.contains("startyTime")
+        assert failureEntity.contains("triggrIds")
+        assert !failureEntity.contains("endTime")
+        assert !failureEntity.contains("alertIds")
+        assert !failureEntity.contains("statuses")
+    }
+
+    @Test
+    void deleteAlerts() {
+        String now = String.valueOf(System.currentTimeMillis());
+
+        def resp = client.delete(path: "badAlertId" )
+        assert resp.status == 404 : resp.status
+
+        resp = client.put(path: "delete", query: [endTime:now, startTime:"0",triggerIds:"Trigger-01,Trigger-02"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.put(path: "delete", query: [endTime:now, startTime:"0",alertIds:"Trigger-01|"+now+","+"Trigger-02|"+now] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.put(path: "delete", query: [endTime:now, startTime:"0",statuses:"OPEN,ACKNOWLEDGED,RESOLVED"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.put(path: "delete", query: [tags:"data-01|*,data-02|*"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.put(path: "delete", query: [tags:"dataId|data-01,dataId|data-02"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.put(path: "delete", query: [tagQuery:"tagA or (tagB and tagC in ['e.*', 'f.*'])"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.put(path: "delete", query: [endResolvedTime:now, startResolvedTime:"0"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.put(path: "delete", query: [endAckTime:now, startAckTime:"0"] )
+        assert resp.status == 200 : resp.status
+
+        resp = client.put(path: "delete", query: [endStatusTime:now, startStatusTime:"0"] )
+        assert resp.status == 200 : resp.status
+    }
+
+}

--- a/external/src/test/groovy/org/hawkular/alerts/rest/ConditionsITest.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/ConditionsITest.groovy
@@ -1,0 +1,465 @@
+package org.hawkular.alerts.rest
+
+import io.quarkus.test.junit.QuarkusTest
+import org.hawkular.alerts.api.json.GroupConditionsInfo
+import org.hawkular.alerts.api.model.condition.*
+import org.hawkular.alerts.api.model.trigger.Mode
+import org.hawkular.alerts.api.model.trigger.Trigger
+import org.junit.jupiter.api.Test
+
+import static org.hawkular.alerts.api.model.condition.AvailabilityCondition.Operator
+import static org.hawkular.alerts.api.model.condition.NelsonCondition.NelsonRule
+import static org.hawkular.alerts.api.model.condition.RateCondition.Direction
+import static org.hawkular.alerts.api.model.condition.RateCondition.Period
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
+
+/**
+ * Conditions REST tests.
+ *
+ * @author Lucas Ponce
+ */
+@QuarkusTest
+class ConditionsITest extends AbstractQuarkusITestBase {
+
+    @Test
+    void createAvailabilityCondition() {
+        Trigger testTrigger = new Trigger("test-trigger-1", "No-Metric");
+
+        // make sure clean test trigger exists
+        client.delete(path: "triggers/test-trigger-1")
+        def resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        AvailabilityCondition testCond = new AvailabilityCondition("test-trigger-1", Mode.FIRING,
+                "No-Metric", Operator.NOT_UP);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( testCond );
+        resp = client.put(path: "triggers/test-trigger-1/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        testCond.setOperator(Operator.UP)
+        resp = client.put(path: "triggers/test-trigger-1/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("UP", resp.data[0].operator)
+
+        conditions.clear();
+        resp = client.put(path: "triggers/test-trigger-1/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(0, resp.data.size())
+
+        resp = client.delete(path: "triggers/test-trigger-1")
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void createCompareCondition() {
+        Trigger testTrigger = new Trigger("test-trigger-2", "No-Metric");
+
+        // make sure clean test trigger exists
+        client.delete(path: "triggers/test-trigger-2")
+        def resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        CompareCondition testCond = new CompareCondition("test-trigger-2", Mode.FIRING,
+                "No-Metric-1", CompareCondition.Operator.LT, 1.0, "No-Metric-2");
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( testCond );
+        resp = client.put(path: "triggers/test-trigger-2/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        testCond.setOperator(CompareCondition.Operator.GT)
+        resp = client.put(path: "triggers/test-trigger-2/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-2/conditions")
+        assertEquals(1, resp.data.size())
+        assertEquals("GT", resp.data[0].operator)
+
+        conditions.clear();
+        resp = client.put(path: "triggers/test-trigger-2/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-2/conditions")
+        assertEquals(0, resp.data.size())
+
+        resp = client.delete(path: "triggers/test-trigger-2")
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void createStringCondition() {
+        Trigger testTrigger = new Trigger("test-trigger-3", "No-Metric");
+
+        // make sure clean test trigger exists
+        client.delete(path: "triggers/test-trigger-3")
+        def resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        StringCondition testCond = new StringCondition("test-trigger-3", Mode.FIRING,
+                "No-Metric", StringCondition.Operator.CONTAINS, "test", false);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( testCond );
+        resp = client.put(path: "triggers/test-trigger-3/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        testCond.setOperator(StringCondition.Operator.ENDS_WITH)
+        resp = client.put(path: "triggers/test-trigger-3/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-3/conditions")
+        assertEquals(1, resp.data.size())
+        assertEquals("ENDS_WITH", resp.data[0].operator)
+
+        conditions.clear();
+        resp = client.put(path: "triggers/test-trigger-3/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-3/conditions")
+        assertEquals(0, resp.data.size())
+
+        resp = client.delete(path: "triggers/test-trigger-3")
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void createThresholdCondition() {
+        Trigger testTrigger = new Trigger("test-trigger-4", "No-Metric");
+
+        // make sure clean test trigger exists
+        client.delete(path: "triggers/test-trigger-4")
+        def resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        ThresholdCondition testCond1 = new ThresholdCondition("test-trigger-4", Mode.FIRING,
+                "No-Metric", ThresholdCondition.Operator.GT, 10.12);
+
+        ThresholdCondition testCond2 = new ThresholdCondition("test-trigger-4", Mode.FIRING,
+                "No-Metric", ThresholdCondition.Operator.LT, 4.10);
+
+        Collection<Condition> conditions = new ArrayList<>(2);
+        conditions.add( testCond1 );
+        conditions.add( testCond2 );
+        resp = client.put(path: "triggers/test-trigger-4/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size())
+
+        resp = client.get(path: "triggers/test-trigger-4/conditions")
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size())
+
+        testCond1.setOperator(ThresholdCondition.Operator.LTE)
+        resp = client.put(path: "triggers/test-trigger-4/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-4/conditions")
+        assertEquals(2, resp.data.size())
+        Set<String> operators = new HashSet<>();
+        operators.add(resp.data[0].operator)
+        operators.add(resp.data[1].operator)
+        assertTrue(operators.contains("LTE"))
+        assertTrue(operators.contains("LT"))
+
+        conditions.clear();
+        conditions.add(testCond2);
+        resp = client.put(path: "triggers/test-trigger-4/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-4/conditions")
+        assertEquals(1, resp.data.size())
+
+        resp = client.delete(path: "triggers/test-trigger-4")
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void createThresholdRangeCondition() {
+        Trigger testTrigger = new Trigger("test-trigger-5", "No-Metric");
+
+        // make sure clean test trigger exists
+        client.delete(path: "triggers/test-trigger-5")
+        def resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        ThresholdRangeCondition testCond = new ThresholdRangeCondition("test-trigger-5", Mode.FIRING,
+                "No-Metric", ThresholdRangeCondition.Operator.INCLUSIVE, ThresholdRangeCondition.Operator.EXCLUSIVE,
+                10.51, 10.99, true);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( testCond );
+        resp = client.put(path: "triggers/test-trigger-5/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        testCond.setOperatorHigh(ThresholdRangeCondition.Operator.INCLUSIVE)
+        resp = client.put(path: "triggers/test-trigger-5/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-5/conditions")
+        assertEquals(1, resp.data.size())
+        assertEquals("INCLUSIVE", resp.data[0].operatorHigh)
+
+        conditions.clear();
+        resp = client.put(path: "triggers/test-trigger-5/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-5/conditions")
+        assertEquals(0, resp.data.size())
+
+        resp = client.delete(path: "triggers/test-trigger-5")
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void createMissingCondition() {
+        Trigger testTrigger = new Trigger("test-trigger-6", "No-Metric");
+
+        // make sure clean test trigger exists
+        client.delete(path: "triggers/test-trigger-6")
+        def resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        MissingCondition testCond = new MissingCondition("test-trigger-6", Mode.FIRING,
+                "No-Metric-1", 1234);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( testCond );
+        resp = client.put(path: "triggers/test-trigger-6/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        testCond.setInterval(5432)
+        resp = client.put(path: "triggers/test-trigger-6/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-6/conditions")
+        assertEquals(1, resp.data.size())
+        assertEquals(5432, resp.data[0].interval)
+
+        conditions.clear();
+        resp = client.put(path: "triggers/test-trigger-6/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-6/conditions")
+        assertEquals(0, resp.data.size())
+
+        resp = client.delete(path: "triggers/test-trigger-6")
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void createNelsonCondition() {
+        Trigger testTrigger = new Trigger("test-trigger-7", "No-Metric");
+
+        // make sure clean test trigger exists
+        client.delete(path: "triggers/test-trigger-7")
+        def resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        Set<NelsonRule> activeRules = new HashSet<>(3);
+        activeRules.add(NelsonRule.Rule3);
+        activeRules.add(NelsonRule.Rule5);
+        activeRules.add(NelsonRule.Rule7);
+        NelsonCondition testCond = new NelsonCondition("test-trigger-7", Mode.FIRING, 1, 1,
+            "No-Metric-1", activeRules, 10);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( testCond );
+        resp = client.put(path: "triggers/test-trigger-7/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        resp = client.get(path: "triggers/test-trigger-7/conditions")
+        assertEquals(1, resp.data.size())
+        assertTrue(resp.data[0].activeRules.contains("Rule3"))
+        assertTrue(resp.data[0].activeRules.contains("Rule5"))
+        assertTrue(resp.data[0].activeRules.contains("Rule7"))
+        assertEquals(10, resp.data[0].sampleSize)
+
+        activeRules.remove(NelsonRule.Rule5)
+        testCond.setActiveRules(activeRules)
+        testCond.setSampleSize(20)
+        resp = client.put(path: "triggers/test-trigger-7/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-7/conditions")
+        assertEquals(1, resp.data.size())
+        assertEquals(2, resp.data[0].activeRules.size())
+        assertTrue(resp.data[0].activeRules.contains("Rule3"))
+        assertTrue(resp.data[0].activeRules.contains("Rule7"))
+        assertEquals(20, resp.data[0].sampleSize)
+
+        conditions.clear();
+        resp = client.put(path: "triggers/test-trigger-7/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-7/conditions")
+        assertEquals(0, resp.data.size())
+
+        resp = client.delete(path: "triggers/test-trigger-7")
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void createRateCondition() {
+        Trigger testTrigger = new Trigger("test-trigger-8", "No-Metric");
+
+        // make sure clean test trigger exists
+        client.delete(path: "triggers/test-trigger-8")
+        def resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        RateCondition testCond = new RateCondition("test-trigger-8", Mode.FIRING,
+                "No-Metric-1", Direction.DECREASING, Period.WEEK, RateCondition.Operator.GT, 10.0);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( testCond );
+        resp = client.put(path: "triggers/test-trigger-8/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("DECREASING", resp.data[0].direction)
+        assertEquals("WEEK", resp.data[0].period)
+        assertEquals("GT", resp.data[0].operator)
+
+        testCond.setDirection(Direction.INCREASING)
+        resp = client.put(path: "triggers/test-trigger-8/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-8/conditions")
+        assertEquals(1, resp.data.size())
+        assertEquals("INCREASING", resp.data[0].direction)
+
+        conditions.clear();
+        resp = client.put(path: "triggers/test-trigger-8/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-8/conditions")
+        assertEquals(0, resp.data.size())
+
+        resp = client.delete(path: "triggers/test-trigger-8")
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void createMultipleTriggerModeConditions() {
+        Trigger testTrigger = new Trigger("test-multiple-mode-conditions", "No-Metric")
+
+        // make sure clean test trigger exists
+        client.delete(path: "triggers/test-multiple-mode-conditions")
+        def resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        ThresholdCondition testCond1 = new ThresholdCondition("test-multiple-mode-conditions", Mode.FIRING,
+                "No-Metric", ThresholdCondition.Operator.GT, 10.12);
+
+        ThresholdCondition testCond2 = new ThresholdCondition("test-multiple-mode-conditions", Mode.AUTORESOLVE,
+                "No-Metric", ThresholdCondition.Operator.LT, 4.10);
+
+        Collection<Condition> conditions = new ArrayList<>(2);
+        conditions.add( testCond1 );
+        conditions.add( testCond2 );
+        resp = client.put(path: "triggers/test-multiple-mode-conditions/conditions", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size())
+
+        resp = client.get(path: "triggers/test-multiple-mode-conditions/conditions")
+        Set<String> modes = new HashSet<>();
+        modes.add(resp.data[0].triggerMode)
+        modes.add(resp.data[1].triggerMode)
+        assertEquals(2, modes.size())
+
+        conditions = Arrays.asList(testCond2)
+
+        resp = client.put(path: "triggers/test-multiple-mode-conditions/conditions", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-multiple-mode-conditions/conditions")
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("AUTORESOLVE", resp.data[0].triggerMode);
+
+        conditions = Collections.EMPTY_LIST
+
+        resp = client.put(path: "triggers/test-multiple-mode-conditions/conditions", body: conditions)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-multiple-mode-conditions/conditions")
+        assertEquals(200, resp.status)
+        assertEquals(0, resp.data.size())
+
+        resp = client.delete(path: "triggers/test-multiple-mode-conditions")
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void createMultipleTriggerModeConditionsInGroups() {
+        Trigger groupTrigger = new Trigger("group-trigger", "group-trigger");
+        groupTrigger.setEnabled(false);
+
+        // remove if it exists
+        def resp = client.delete(path: "triggers/groups/group-trigger", query: [keepNonOrphans:false,keepOrphans:false])
+        assert(200 == resp.status || 404 == resp.status)
+
+        // create the group
+        resp = client.post(path: "triggers/groups", body: groupTrigger)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/group-trigger")
+        assertEquals(200, resp.status)
+        groupTrigger = (Trigger)resp.data;
+        assertEquals( true, groupTrigger.isGroup() );
+
+        ThresholdCondition cond1 = new ThresholdCondition("group-trigger", Mode.FIRING, "DataId1-Token",
+                ThresholdCondition.Operator.GT, 10.0);
+        ThresholdCondition cond2 = new ThresholdCondition("group-trigger", Mode.AUTORESOLVE, "DataId2-Token",
+                ThresholdCondition.Operator.LT, 20.0);
+
+        Map<String, Map<String, String>> dataIdMemberMap = new HashMap<>();
+        GroupConditionsInfo groupConditionsInfo = new GroupConditionsInfo(Arrays.asList(cond1, cond2), dataIdMemberMap)
+
+        resp = client.put(path: "triggers/groups/group-trigger/conditions", body: groupConditionsInfo)
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size())
+
+        // get the group conditions
+        resp = client.get(path: "triggers/group-trigger/conditions")
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size());
+
+        Set<String> modes = new HashSet<>();
+        modes.add(resp.data[0].triggerMode)
+        modes.add(resp.data[1].triggerMode)
+        assertEquals(2, modes.size())
+
+        groupConditionsInfo.setConditions(Arrays.asList(cond2))
+
+        resp = client.put(path: "triggers/groups/group-trigger/conditions", body: groupConditionsInfo)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/group-trigger/conditions")
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size());
+        assertEquals("AUTORESOLVE", resp.data[0].triggerMode);
+
+        groupConditionsInfo.setConditions(Collections.EMPTY_LIST)
+
+        resp = client.put(path: "triggers/groups/group-trigger/conditions", body: groupConditionsInfo)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/group-trigger/conditions")
+        assertEquals(200, resp.status)
+        assertEquals(0, resp.data.size());
+
+        // remove group trigger
+        resp = client.delete(path: "triggers/groups/group-trigger")
+        assertEquals(200, resp.status)
+    }
+}

--- a/external/src/test/groovy/org/hawkular/alerts/rest/DampeningITest.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/DampeningITest.groovy
@@ -1,0 +1,64 @@
+package org.hawkular.alerts.rest
+
+import io.quarkus.test.junit.QuarkusTest
+import org.hawkular.alerts.api.model.dampening.Dampening
+import org.hawkular.alerts.api.model.dampening.Dampening.Type
+import org.hawkular.alerts.api.model.trigger.Mode
+import org.hawkular.alerts.api.model.trigger.Trigger
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+/**
+ * Dampening REST tests.
+ *
+ * @author Lucas Ponce
+ */
+@QuarkusTest
+class DampeningITest extends AbstractQuarkusITestBase {
+
+    @Test
+    void createDampening() {
+       Trigger testTrigger = new Trigger("test-trigger-6", "No-Metric");
+
+        // make sure clean test trigger exists
+        client.delete(path: "triggers/test-trigger-6")
+        def resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        Dampening d = Dampening.forRelaxedCount("", "test-trigger-6", Mode.FIRING, 1, 2);
+
+        resp = client.post(path: "triggers/test-trigger-6/dampenings", body: d)
+        assertEquals(200, resp.status)
+
+        d = resp.data
+
+        resp = client.get(path: "triggers/test-trigger-6/dampenings/" + d.getDampeningId());
+        assertEquals(200, resp.status)
+        assertEquals("RELAXED_COUNT", resp.data.type)
+
+        d.setType(Type.STRICT)
+        resp = client.put(path: "triggers/test-trigger-6/dampenings/" + d.getDampeningId(), body: d)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-6/dampenings/" + d.getDampeningId())
+        assertEquals(200, resp.status)
+        assertEquals("STRICT", resp.data.type)
+
+        resp = client.get(path: "triggers/test-trigger-6/dampenings")
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        resp = client.get(path: "triggers/test-trigger-6/dampenings/mode/FIRING")
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("test-trigger-6", resp.data[0].triggerId)
+
+        resp = client.delete(path: "triggers/test-trigger-6/dampenings/" + d.getDampeningId())
+        assertEquals(200, resp.status)
+
+        client.delete(path: "triggers/test-trigger-6")
+        assertEquals(200, resp.status)
+    }
+
+}

--- a/external/src/test/groovy/org/hawkular/alerts/rest/EventsITest.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/EventsITest.groovy
@@ -1,0 +1,235 @@
+package org.hawkular.alerts.rest
+
+
+import io.quarkus.test.junit.QuarkusTest
+import org.hawkular.alerts.api.model.event.Event
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+/**
+ * Events REST tests.
+ *
+ * @author Lucas Ponce
+ */
+@QuarkusTest
+class EventsITest extends AbstractQuarkusITestBase {
+
+    @Test
+    void findEvents() {
+        def resp = client.get(path: "events")
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void findEventsByCriteria() {
+        String now = String.valueOf(System.currentTimeMillis());
+        def resp = client.get(path: "events", query: [endTime:now, startTime:"0",triggerIds:"Trigger-01,Trigger-02"] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "events",
+                          query: [endTime:now, startTime:"0",eventIds:"Trigger-01|"+now+","+"Trigger-02|"+now] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "events", query: [endTime:now, startTime:"0",categories:"ALERT,LOG"] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "events", query: [tags:"tag-01|*,tag-02|*"] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "events", query: [tags:"tag-01|value-01,tag-02|value-02",thin:true] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "events", query: [tagQuery:"tagA or (tagB and tagC in ['e.*', 'f.*'])"] )
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void deleteEvents() {
+        String now = String.valueOf(System.currentTimeMillis());
+
+        def resp = client.delete(path: "events/badEventId" )
+        assertEquals(404, resp.status)
+
+        resp = client.put(path: "events/delete",
+                          query: [endTime:now, startTime:"0",triggerIds:"Trigger-01,Trigger-02"] )
+        assertEquals(200, resp.status)
+
+        resp = client.put(path: "events/delete",
+                          query: [endTime:now, startTime:"0", eventIds:"Trigger-01|"+now+","+"Trigger-02|"+now] )
+        assertEquals(200, resp.status)
+
+        resp = client.put(path: "events/delete",
+                          query: [endTime:now, startTime:"0",categories:"A,B,C"] )
+        assertEquals(200, resp.status)
+
+        resp = client.put(path: "events/delete", query: [tags:"tag-01|*,tag-02|*"] )
+        assertEquals(200, resp.status)
+
+        resp = client.put(path: "events/delete", query: [tags:"tag-01|value-01,tag-02|value-02"] )
+        assertEquals(200, resp.status)
+
+        resp = client.put(path: "events/delete", query: [tagQuery:"tagA or (tagB and tagC in ['e.*', 'f.*'])"] )
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void createEvent() {
+        String now = String.valueOf(System.currentTimeMillis());
+
+        Map context = new java.util.HashMap();
+        context.put("event-context-name", "event-context-value");
+        Map tags = new java.util.HashMap();
+        tags.put("event-tag-name", "event-tag-value");
+        Event event = new Event("test-tenant", "test-event-id", System.currentTimeMillis(), "test-event-data-id",
+                "test-category", "test event text", context, tags);
+
+        client.delete(path: "events/test-event-id" )
+
+        def resp = client.post(path: "events", body: event )
+        assertEquals(200, resp.status)
+        event = resp.data
+        assertEquals("test-event-id", event.getId())
+
+        resp = client.post(path: "events", body: event )
+        assertEquals(400, resp.status)
+
+        resp = client.get(path: "events/event/test-event-id" )
+        assertEquals(200, resp.status)
+
+        Event e = resp.data
+        assertEquals(event, e)
+        assertEquals("test-category", e.getCategory())
+        assertEquals("test event text", e.getText())
+        assertEquals(context, e.getContext())
+        assertEquals(tags, e.getTags())
+
+        resp = client.get(path: "events", query: [startTime:now,tags:"event-tag-name|event-tag-value"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size)
+
+        e = resp.data[0]
+
+        resp = client.put(path: "events/tags", query: [eventIds:e.id,tags:"tag1name|tag1value"] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "events", query: [startTime:now,tags:"tag1name|tag1value"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        e = resp.data[0]
+        assertEquals(2, e.tags.size())
+        assertEquals("event-tag-value", e.tags.get("event-tag-name"))
+        assertEquals("tag1value", e.tags.get("tag1name"))
+
+        resp = client.delete(path: "events/tags", query: [eventIds:e.id,tagNames:"tag1name"] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "events", query: [startTime:now,tags:"tag1name|tag1value"] )
+        assertEquals(200, resp.status)
+        assertEquals(0, resp.data.size())
+
+        resp = client.delete(path: "events/test-event-id" )
+        assert resp.status == 200 : resp.status
+
+        resp = client.get(path: "events/event/test-event-id" )
+        assert resp.status == 404 : resp.status
+    }
+
+    @Test
+    void sendAndNoPersistEvents() {
+        String now = String.valueOf(System.currentTimeMillis());
+
+        Event event = new Event("test-tenant", "test-event-id", System.currentTimeMillis(), "test-event-data-id",
+                "test-category", "test event text");
+        Collection<Event> events = Arrays.asList(event);
+
+        def resp = client.post(path: "events/data", body: events )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "events/event/test-event-id" )
+        assertEquals(404, resp.status)
+
+        resp = client.get(path: "events", query: [startTime:now] )
+        assertEquals(200, resp.status)
+        assertEquals(0, resp.data.size())
+    }
+
+    @Test
+    void testQueryEventsWithSpacesInValues() {
+        Event e1 = new Event();
+        e1.setId("test_1");
+        e1.setCtime(1499452337498L);
+        e1.setCategory("test");
+        e1.setText("Avail-changed:[UP] WildFly Server");
+        e1.getContext().put("resource_path", "/t;hawkular/f;my-agent/r;Local%20DMR~~");
+        e1.getContext().put("message", "Avail-changed:[UP] WildFly Server");
+        e1.getTags().put("test_tag", "/t;hawkular/f;my-agent/r;Local%20DMR~~_Server Availability");
+
+        def resp = client.post(path: "events", body: e1)
+        assertEquals(200, resp.status)
+        def event = resp.data
+        assertEquals("test_1", event.id)
+
+        Event e2 = new Event();
+        e2.setId("test_2");
+        e2.setCtime(1499445265683L);
+        e2.setCategory("test");
+        e2.setText("Avail-changed:[DOWN] Deployment");
+        e2.getContext().put("resource_path", "/t;hawkular/f;my-agent/r;Local%20DMR~%2Fdeployment%3Dcfme_test_ear_middleware.ear");
+        e2.getContext().put("message", "Avail-changed:[DOWN] Deployment");
+        e2.getTags().put("test_tag", "/t;hawkular/f;my-agent/r;Local%20DMR~%2Fdeployment%3Dcfme_test_ear_middleware.ear_Deployment Status");
+
+        resp = client.post(path: "events", body: e2)
+        assertEquals(200, resp.status)
+        event = resp.data
+        assertEquals("test_2", event.id)
+
+        def tagQuery = "test_tag = '\\/t;hawkular\\/f;my-agent\\/r;Local%20DMR\\~\\~_Server Availability'"
+
+        resp = client.get(path: "events", query: [tagQuery: tagQuery] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+    }
+
+    // HWKALERTS-275
+    @Test
+    void testCreateAndQueryEvents() {
+        def numEvents = 1000
+        def resp
+        for (int i = 0; i < numEvents; i++) {
+            Event eventX = new Event()
+            eventX.setId("event" + i)
+            eventX.setCategory("test")
+            eventX.setText("Event message " + i)
+            eventX.getTags().put("tag" + (i % 3), "value" + (i % 3))
+            resp = client.post(path: "events", body: eventX)
+            assertEquals(200, resp.status)
+        }
+
+        def tagQuery = "tag0"
+        resp = client.get(path: "events", query: [tagQuery: tagQuery])
+        assertEquals(200, resp.status)
+        assertEquals(334, resp.data.size())
+
+        tagQuery = "tag1"
+        resp = client.get(path: "events", query: [tagQuery: tagQuery])
+        assertEquals(200, resp.status)
+        assertEquals(333, resp.data.size())
+
+        tagQuery = "tag2"
+        resp = client.get(path: "events", query: [tagQuery: tagQuery])
+        assertEquals(200, resp.status)
+        assertEquals(333, resp.data.size())
+
+        def eventIds = ""
+        for (int i = 0; i < 199; i++) {
+            eventIds += "event" + i + ",";
+        }
+        eventIds += "event199";
+
+        resp = client.get(path: "events", query: [eventIds: eventIds])
+        assertEquals(200, resp.status)
+        assertEquals(200, resp.data.size())
+    }
+}

--- a/external/src/test/groovy/org/hawkular/alerts/rest/EventsLifecycleITest.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/EventsLifecycleITest.groovy
@@ -1,0 +1,515 @@
+package org.hawkular.alerts.rest
+
+import io.quarkus.test.junit.QuarkusTest
+import org.hawkular.alerts.api.model.condition.Condition
+import org.hawkular.alerts.api.model.condition.EventCondition
+import org.hawkular.alerts.api.model.condition.MissingCondition
+import org.hawkular.alerts.api.model.event.EventCategory
+import org.hawkular.alerts.api.model.event.EventType
+import org.hawkular.alerts.api.model.trigger.Mode
+import org.hawkular.alerts.api.model.trigger.Trigger
+import org.hawkular.commons.log.MsgLogger
+import org.hawkular.commons.log.MsgLogging
+import org.junit.jupiter.api.TestMethodOrder
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+/**
+ * Events lifecycle end-to-end tests.
+ *
+ * @author Jay Shaughnessy
+ * @author Lucas Ponce
+ */
+@TestMethodOrder(MethodOrderer.Alphanumeric.class)
+@QuarkusTest
+class EventsLifecycleITest extends AbstractQuarkusITestBase {
+
+    static MsgLogger logger = MsgLogging.getMsgLogger(EventsLifecycleITest.class)
+
+    @Test
+    void t01_eventsBasicTest() {
+        logger.info( "Running t01_eventsBasicTest" )
+
+        String start = String.valueOf(System.currentTimeMillis())
+
+        // Clean previous tests
+        def resp = client.delete(path: "triggers/test-events-t01")
+        assert(200 == resp.status || 404 == resp.status)
+
+        // Trigger to fire alerts
+        Trigger t01 = new Trigger("test-events-t01", "Basic trigger for Events tests");
+
+        resp = client.post(path: "triggers", body: t01)
+        assertEquals(200, resp.status)
+
+        // Add a condition over events
+        EventCondition firingCond = new EventCondition("test-events-t01", Mode.FIRING, "test-app.war", null);
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+
+        resp = client.put(path: "triggers/test-events-t01/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // Enable trigger
+        resp = client.put(path: "triggers/enabled", query:[triggerIds:"test-events-t01",enabled:true] )
+        assertEquals(200, resp.status)
+
+        String jsonEvent = "{" +
+                "\"id\":\"" + UUID.randomUUID().toString() + "\"," +
+                "\"ctime\":" + System.currentTimeMillis() + "," +
+                "\"category\":\"" + EventCategory.DEPLOYMENT.toString() + "\"," +
+                "\"dataId\":\"test-app.war\"" +
+                "}";
+
+        resp = client.post(path: "events", body: jsonEvent);
+        assertEquals(200, resp.status)
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 100; ++i ) {
+            Thread.sleep(100);
+
+            // FETCH recent alerts for trigger, there should be 1
+//            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-events-t01"] )
+            resp = client.get(path: "", query: [triggerIds:"test-events-t01"] )
+            if ( resp.status == 200 && resp.data != null && resp.data.size > 0) {
+                if ( i > 50 ) {
+                    logger.info( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+    }
+
+    @Test
+    void t02_eventsChainedTest() {
+        logger.info( "Running t02_eventsChainedTest" )
+
+        String start = String.valueOf(System.currentTimeMillis())
+
+        // Clean previous tests
+        def resp = client.delete(path: "triggers/test-events-t02-app1")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-events-t02-app2")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-events-t02-combined")
+        assert(200 == resp.status || 404 == resp.status)
+
+        // Triggers to fire events
+        Trigger t02app1 = new Trigger("test-events-t02-app1", "Check if app1 is down");
+        t02app1.setEventType(EventType.EVENT);
+
+        resp = client.post(path: "triggers", body: t02app1)
+        assertEquals(200, resp.status)
+
+        // Add a condition over events
+        EventCondition firingCond1 = new EventCondition("test-events-t02-app1", Mode.FIRING, "app1.war",
+            "text == 'DOWN'");
+        Collection<Condition> conditions1 = new ArrayList<>(1);
+        conditions1.add( firingCond1 );
+
+        resp = client.put(path: "triggers/test-events-t02-app1/conditions/firing", body: conditions1)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // Enable trigger
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-events-t02-app1",enabled:true])
+        assertEquals(200, resp.status)
+
+        // Triggers to fire events
+        Trigger t02app2 = new Trigger("test-events-t02-app2", "Check if app2 is down");
+        t02app2.setEventType(EventType.EVENT);
+
+        resp = client.post(path: "triggers", body: t02app2)
+        assertEquals(200, resp.status)
+
+        // Add a condition over events
+        EventCondition firingCond2 = new EventCondition("test-events-t02-app2", Mode.FIRING, "app2.war",
+            "text == 'DOWN'");
+        Collection<Condition> conditions2 = new ArrayList<>(1);
+        conditions2.add( firingCond2 );
+
+        resp = client.put(path: "triggers/test-events-t02-app2/conditions/firing", body: conditions2)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // Enable trigger
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-events-t02-app2",enabled:true])
+        assertEquals(200, resp.status)
+
+        // Trigger to fire alerts
+        Trigger t02combined = new Trigger("test-events-t02-combined", "App1 and App2 are down");
+
+        resp = client.post(path: "triggers", body: t02combined)
+        assertEquals(200, resp.status)
+
+        // Add a condition over events
+        EventCondition firingCond3 = new EventCondition("test-events-t02-combined", Mode.FIRING,
+            "test-events-t02-app1", null);
+        EventCondition firingCond4 = new EventCondition("test-events-t02-combined", Mode.FIRING,
+            "test-events-t02-app2", null);
+
+        Collection<Condition> conditions3 = new ArrayList<>(2);
+        conditions3.add( firingCond3 );
+        conditions3.add( firingCond4 );
+
+        resp = client.put(path: "triggers/test-events-t02-combined/conditions/firing", body: conditions3)
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size())
+
+        // Enable trigger
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-events-t02-combined",enabled:true])
+        assertEquals(200, resp.status)
+
+        String jsonEventApp1Down = "{" +
+                "\"id\":\"" + UUID.randomUUID().toString() + "\"," +
+                "\"ctime\":" + System.currentTimeMillis() + "," +
+                "\"category\":\"" + EventCategory.DEPLOYMENT.toString() + "\"," +
+                "\"dataId\":\"app1.war\"," +
+                "\"text\":\"DOWN\"" +
+                "}";
+
+        resp = client.post(path: "events", body: jsonEventApp1Down);
+        assertEquals(200, resp.status)
+
+        String jsonEventApp2Down = "{" +
+                "\"id\":\"" + UUID.randomUUID().toString() + "\"," +
+                "\"ctime\":" + System.currentTimeMillis() + "," +
+                "\"category\":\"" + EventCategory.DEPLOYMENT.toString() + "\"," +
+                "\"dataId\":\"app2.war\"," +
+                "\"text\":\"DOWN\"" +
+                "}";
+
+        resp = client.post(path: "events", body: jsonEventApp2Down);
+        assertEquals(200, resp.status)
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 100; ++i ) {
+            Thread.sleep(100);
+
+            // FETCH recent alerts for trigger, there should be 1
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-events-t02-combined"] )
+            if ( resp.status == 200 && resp.data != null && resp.data.size > 0) {
+                if ( i > 50 ) {
+                    logger.info( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+    }
+
+    @Test
+    void t03_eventsChainedWithoutPersistingInputEventsTest() {
+        logger.info( "Running t03_eventsChainedWithoutPersistingInputEventsTest" )
+
+        String start = String.valueOf(System.currentTimeMillis())
+
+        // Clean previous tests
+        def resp = client.delete(path: "triggers/test-events-t03-app1")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-events-t03-app2")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-events-t03-combined")
+        assert(200 == resp.status || 404 == resp.status)
+
+        // Triggers to fire events
+        Trigger t03app1 = new Trigger("test-events-t03-app1", "Check if app1 is down");
+        t03app1.setEventType(EventType.EVENT);
+
+        resp = client.post(path: "triggers", body: t03app1)
+        assertEquals(200, resp.status)
+
+        // Add a condition over events
+        EventCondition firingCond1 = new EventCondition("test-events-t03-app1", Mode.FIRING, "app1-03.war",
+                "text == 'DOWN'");
+        Collection<Condition> conditions1 = new ArrayList<>(1);
+        conditions1.add( firingCond1 );
+
+        resp = client.put(path: "triggers/test-events-t03-app1/conditions/firing", body: conditions1)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // Enable trigger
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-events-t03-app1",enabled:true])
+        assertEquals(200, resp.status)
+
+        // Triggers to fire events
+        Trigger t03app2 = new Trigger("test-events-t03-app2", "Check if app2 is down");
+        t03app2.setEventType(EventType.EVENT);
+
+        resp = client.post(path: "triggers", body: t03app2)
+        assertEquals(200, resp.status)
+
+        // Add a condition over events
+        EventCondition firingCond2 = new EventCondition("test-events-t03-app2", Mode.FIRING, "app2-03.war",
+                "text == 'DOWN'");
+        Collection<Condition> conditions2 = new ArrayList<>(1);
+        conditions2.add( firingCond2 );
+
+        resp = client.put(path: "triggers/test-events-t03-app2/conditions/firing", body: conditions2)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // Enable trigger
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-events-t03-app2",enabled:true])
+        assertEquals(200, resp.status)
+
+        // Trigger to fire alerts
+        Trigger t03combined = new Trigger("test-events-t03-combined", "App1 and App2 are down");
+
+        resp = client.post(path: "triggers", body: t03combined)
+        assertEquals(200, resp.status)
+
+        // Add a condition over events
+        EventCondition firingCond3 = new EventCondition("test-events-t03-combined", Mode.FIRING,
+                "test-events-t03-app1", null);
+        EventCondition firingCond4 = new EventCondition("test-events-t03-combined", Mode.FIRING,
+                "test-events-t03-app2", null);
+
+        Collection<Condition> conditions3 = new ArrayList<>(2);
+        conditions3.add( firingCond3 );
+        conditions3.add( firingCond4 );
+
+        resp = client.put(path: "triggers/test-events-t03-combined/conditions/firing", body: conditions3)
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size())
+
+        // Enable trigger
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-events-t03-combined",enabled:true])
+        assertEquals(200, resp.status)
+
+        String jsonEventApp1DownId = UUID.randomUUID().toString();
+        String jsonEventApp1Down = "[{" +
+                "\"id\":\"" + jsonEventApp1DownId + "\"," +
+                "\"ctime\":" + System.currentTimeMillis() + "," +
+                "\"category\":\"" + EventCategory.DEPLOYMENT.toString() + "\"," +
+                "\"dataId\":\"app1-03.war\"," +
+                "\"text\":\"DOWN\"" +
+                "}]";
+
+        resp = client.post(path: "events/data", body: jsonEventApp1Down);
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "events/event/" + jsonEventApp1DownId);
+        assertEquals(404, resp.status)
+
+        String jsonEventApp2DownId = UUID.randomUUID().toString();
+        String jsonEventApp2Down = "[{" +
+                "\"id\":\"" + jsonEventApp2DownId + "\"," +
+                "\"ctime\":" + System.currentTimeMillis() + "," +
+                "\"category\":\"" + EventCategory.DEPLOYMENT.toString() + "\"," +
+                "\"dataId\":\"app2-03.war\"," +
+                "\"text\":\"DOWN\"" +
+                "}]";
+
+        resp = client.post(path: "events/data", body: jsonEventApp2Down);
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "events/event/" + jsonEventApp2DownId);
+        assertEquals(404, resp.status)
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 100; ++i ) {
+            Thread.sleep(100);
+
+            // FETCH recent alerts for trigger, there should be 1
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-events-t03-combined"] )
+            if ( resp.status == 200 && resp.data != null && resp.data.size > 0) {
+                if ( i > 50 ) {
+                    logger.info( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+    }
+
+    @Test
+    void t04_missingEventsTest() {
+        logger.info( "Running t04_missingEventsTest" )
+
+        String start = String.valueOf(System.currentTimeMillis())
+
+        // Clean previous tests
+        def resp = client.delete(path: "triggers/test-events-t04")
+        assert(200 == resp.status || 404 == resp.status)
+
+        // Triggers to fire events
+        Trigger t04 = new Trigger("test-events-t04", "Check if we receive events on 5 secs");
+        t04.setEventType(EventType.EVENT);
+
+        resp = client.post(path: "triggers", body: t04)
+        assertEquals(200, resp.status)
+
+        MissingCondition firingCond = new MissingCondition("test-events-t04", Mode.FIRING,
+            "event-data-id-t04", 5000L);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+
+        resp = client.put(path: "triggers/test-events-t04/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // Enable trigger
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-events-t04",enabled:true])
+        assertEquals(200, resp.status)
+
+        // Wait for 7 seconds to fire the missing events
+        Thread.sleep(7000);
+
+        resp = client.get(path: "events", query: [startTime:start,triggerIds:"test-events-t04"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // Clean previous tests
+        resp = client.delete(path: "triggers/test-events-t04")
+        assert(200 == resp.status || 404 == resp.status)
+    }
+
+    @Test
+    void t05_missingEventsWithDataTest() {
+        logger.info( "Running t05_missingEventsWithDataTest" )
+
+        String start = String.valueOf(System.currentTimeMillis())
+
+        // Clean previous tests
+        def resp = client.delete(path: "triggers/test-events-t05")
+        assert(200 == resp.status || 404 == resp.status)
+
+        // Triggers to fire events
+        Trigger t05 = new Trigger("test-events-t05", "Check if we receive events on 5 secs");
+        t05.setEventType(EventType.EVENT);
+
+        resp = client.post(path: "triggers", body: t05)
+        assertEquals(200, resp.status)
+
+        MissingCondition firingCond = new MissingCondition("test-events-t05", Mode.FIRING, "event-data-id-t05", 5000L);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+
+        resp = client.put(path: "triggers/test-events-t05/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // Enable trigger
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-events-t05",enabled:true])
+        assertEquals(200, resp.status)
+
+        Thread.sleep(2000);
+
+        String jsonEventTest05Id = UUID.randomUUID().toString();
+        String jsonEventTest05 = "[{" +
+                "\"id\":\"" + jsonEventTest05Id + "\"," +
+                "\"ctime\":" + System.currentTimeMillis() + "," +
+                "\"category\":\"Test05\"," +
+                "\"dataId\":\"event-data-id-t05\"," +
+                "\"text\":\"Test05 text\"" +
+                "}]";
+
+        resp = client.post(path: "events/data", body: jsonEventTest05);
+        assertEquals(200, resp.status)
+
+        Thread.sleep(2000);
+
+        jsonEventTest05Id = UUID.randomUUID().toString();
+        jsonEventTest05 = "[{" +
+                "\"id\":\"" + jsonEventTest05Id + "\"," +
+                "\"ctime\":" + System.currentTimeMillis() + "," +
+                "\"category\":\"Test05\"," +
+                "\"dataId\":\"event-data-id-t05\"," +
+                "\"text\":\"Test05 text\"" +
+                "}]";
+
+        resp = client.post(path: "events/data", body: jsonEventTest05);
+        assertEquals(200, resp.status)
+
+        Thread.sleep(2000);
+
+        jsonEventTest05Id = UUID.randomUUID().toString();
+        jsonEventTest05 = "[{" +
+                "\"id\":\"" + jsonEventTest05Id + "\"," +
+                "\"ctime\":" + System.currentTimeMillis() + "," +
+                "\"category\":\"Test05\"," +
+                "\"dataId\":\"event-data-id-t05\"," +
+                "\"text\":\"Test05 text\"" +
+                "}]";
+
+        resp = client.post(path: "events/data", body: jsonEventTest05);
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "events", query: [startTime:start,triggerIds:"test-events-t05"] )
+        assertEquals(200, resp.status)
+        assertEquals(0, resp.data.size())
+
+        // Clean previous tests
+        resp = client.delete(path: "triggers/test-events-t05")
+        assert(200 == resp.status || 404 == resp.status)
+    }
+
+    @Test
+    void t100_eventsCleanup() {
+        logger.info("Running t100_eventsCleanup")
+
+        // clean up triggers
+        def resp = client.delete(path: "triggers/test-events-t01")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-events-t02-app1")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-events-t02-app2")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-events-t02-combined")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-events-t03-app1")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-events-t03-app2")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-events-t03-combined")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-events-t04")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-events-t05")
+        assert(200 == resp.status || 404 == resp.status)
+
+        // clean up alerts
+        resp = client.put(path: "delete", query: [triggerIds:"test-events-t01"])
+        assertEquals(200, resp.status)
+
+        resp = client.put(path: "delete", query: [triggerIds:"test-events-t02-combined"])
+        assertEquals(200, resp.status)
+
+        resp = client.put(path: "events/delete", query: [triggerIds:"test-events-t04"])
+        assertEquals(200, resp.status)
+
+        resp = client.put(path: "events/delete", query: [triggerIds:"test-events-t05"])
+        assertEquals(200, resp.status)
+
+        // clean up events
+        resp = client.put(path: "events/delete", query: [categories:"DEPLOYMENT"] )
+        assertEquals(200, resp.status)
+    }
+
+}

--- a/external/src/test/groovy/org/hawkular/alerts/rest/GroupITest.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/GroupITest.groovy
@@ -1,0 +1,233 @@
+package org.hawkular.alerts.rest
+
+import io.quarkus.test.junit.QuarkusTest
+import org.hawkular.alerts.api.json.GroupConditionsInfo
+import org.hawkular.alerts.api.model.Severity
+import org.hawkular.alerts.api.model.condition.AvailabilityCondition
+import org.hawkular.alerts.api.model.condition.Condition
+import org.hawkular.alerts.api.model.trigger.Mode
+import org.hawkular.alerts.api.model.trigger.Trigger
+import org.hawkular.alerts.api.model.trigger.TriggerType
+import org.hawkular.commons.log.MsgLogger
+import org.hawkular.commons.log.MsgLogging
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import org.junit.jupiter.api.MethodOrderer
+
+import static org.hawkular.alerts.api.model.condition.AvailabilityCondition.Operator
+import static org.junit.jupiter.api.Assertions.*
+
+/**
+ * Alerts REST tests.
+ *
+ * @author Jay Shaughnessy
+ */
+@TestMethodOrder(MethodOrderer.Alphanumeric.class)
+@QuarkusTest
+class GroupITest extends AbstractQuarkusITestBase {
+
+    static MsgLogger logger = MsgLogging.getMsgLogger(GroupITest.class)
+
+    static host = System.getProperty('hawkular.host') ?: '127.0.0.1'
+    static port = Integer.valueOf(System.getProperty('hawkular.port') ?: "8081")
+    static t01Start = String.valueOf(System.currentTimeMillis())
+    static t02Start;
+
+    @Test
+    void t01_dataDrivenGroupTest() {
+        logger.info( "Running t01_dataDrivenGroupTest")
+        String start = t01Start;
+
+        // CREATE the data-driven group trigger
+        def resp = client.get(path: "")
+        assertEquals(200, resp.status)
+
+        // sub-test: add context and ensure it carries through to the members
+        Map<String, String> context = new HashMap<>(1);
+        context.put("contextName","contextValue");
+        context.put("contextName2","contextValue2");
+        Trigger testTrigger = new Trigger("test-ddgroup-trigger", "test-ddgroup-trigger", context);
+
+        // sub-test: add tag and ensure it carries through to the members
+        testTrigger.addTag("test-ddgroup-tname","test-ddgroup-tvalue");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/groups/test-ddgroup-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setType(TriggerType.DATA_DRIVEN_GROUP);
+        testTrigger.setAutoDisable(false);
+        testTrigger.setAutoResolve(false);
+        testTrigger.setSeverity(Severity.LOW);
+
+        resp = client.post(path: "triggers/groups", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing condition
+        AvailabilityCondition firingCond = new AvailabilityCondition("test-ddgroup-trigger",
+                Mode.FIRING, "test-ddgroup-avail", Operator.NOT_UP);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+        resp = client.put(path: "triggers/test-ddgroup-trigger/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        testTrigger.setEnabled(true);
+
+        resp = client.put(path: "triggers/groups/test-ddgroup-trigger", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-ddgroup-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-ddgroup-trigger", resp.data.name)
+        assertTrue(resp.data.enabled)
+        assertFalse(resp.data.autoDisable);
+        assertFalse(resp.data.autoEnable);
+        assertEquals("LOW", resp.data.severity);
+        assertNotNull(resp.data.context);
+        assertEquals("contextValue", resp.data.context.get("contextName"));
+        assertEquals("contextValue2", resp.data.context.get("contextName2"));
+        assertEquals("DATA_DRIVEN_GROUP", resp.data.type);
+
+        // FETCH members, should not be any
+        resp = client.get(path: "triggers/groups/test-ddgroup-trigger/members")
+        assertEquals(200, resp.status)
+        assertEquals(0, resp.data.size)
+
+        // Send in avail data to create Source-1 member
+        String jsonData = "[{\"source\":\"Source-1\",\"id\":\"test-ddgroup-avail\",\"timestamp\":" + System.currentTimeMillis() + ",\"value\":\"UP\"}]";
+        resp = client.post(path: "data", body: jsonData);
+        assertEquals(200, resp.status)
+
+        // Send in avail data to create Source-2 member
+        jsonData = "[{\"source\":\"Source-2\",\"id\":\"test-ddgroup-avail\",\"timestamp\":" + System.currentTimeMillis() + ",\"value\":\"UP\"}]";
+        resp = client.post(path: "data", body: jsonData);
+        assertEquals(200, resp.status)
+
+        // The member creation/alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH members for group trigger, there should be 2
+            resp = client.get(path: "triggers/groups/test-ddgroup-trigger/members")
+            if ( resp.status == 200 && resp.data != null && resp.data.size > 1) {
+                if ( i > 10 ) {
+                    logger.info( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size())
+
+        // VALIDATE member triggers
+        Trigger mt1 = resp.data[0]
+        Trigger mt2 = resp.data[1]
+        if ( mt1.id != "test-ddgroup-trigger_Source-1" ) {
+          mt1 = resp.data[1];
+          mt2 = resp.data[0];
+        }
+        assertEquals("test-ddgroup-trigger_Source-1", mt1.id)
+        assertEquals("test-ddgroup-trigger_Source-2", mt2.id)
+        assertEquals("test-ddgroup-trigger", mt1.name)
+        assertEquals("test-ddgroup-trigger", mt2.name)
+        assertEquals(TriggerType.MEMBER, mt1.type)
+        assertEquals(TriggerType.MEMBER, mt2.type)
+        assertEquals("test-ddgroup-trigger", mt1.memberOf)
+        assertEquals("test-ddgroup-trigger", mt2.memberOf)
+        assertEquals("contextValue", mt1.context.get("contextName"));
+        assertEquals("contextValue2", mt1.context.get("contextName2"));
+        assertEquals("contextValue", mt2.context.get("contextName"));
+        assertEquals("contextValue2", mt2.context.get("contextName2"));
+
+        // Send in avail data to create Source-1 alert
+        jsonData = "[{\"source\":\"Source-1\",\"id\":\"test-ddgroup-avail\",\"timestamp\":" + (System.currentTimeMillis() + 1000) + ",\"value\":\"DOWN\"}]";
+        resp = client.post(path: "data", body: jsonData);
+        assertEquals(200, resp.status)
+
+        // Send in avail data to generate Source-2 alert
+        jsonData = "[{\"source\":\"Source-2\",\"id\":\"test-ddgroup-avail\",\"timestamp\":" + (System.currentTimeMillis() + 1000) + ",\"value\":\"DOWN\"}]";
+        resp = client.post(path: "data", body: jsonData);
+        assertEquals(200, resp.status)
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH alerts for member triggers, there should be 2
+            resp = client.get(path: "",
+                              query: [startTime:start,
+                                      triggerIds:"test-ddgroup-trigger_Source-1,test-ddgroup-trigger_Source-2"] )
+            if ( resp.status == 200 && resp.data != null && resp.data.size > 1) {
+                if ( i > 10 ) {
+                    logger.info( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size())
+
+        // Test to make sure disabling the group trigger disables the member triggers (and updates the rule base)
+
+        // DISABLE Trigger
+        resp = client.put(path: "triggers/groups/enabled", query: [triggerIds:"test-ddgroup-trigger",enabled:false])
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-ddgroup-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-ddgroup-trigger", resp.data.name)
+        assertFalse(resp.data.enabled)
+
+        // FETCH members, should not be any
+        resp = client.get(path: "triggers/groups/test-ddgroup-trigger/members")
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size)
+        assertFalse(resp.data[0].enabled)
+        assertFalse(resp.data[1].enabled)
+
+        // Send in avail data to create Source-1 alert if it were enabled (it should not generate an alert)
+        jsonData = "[{\"source\":\"Source-1\",\"id\":\"test-ddgroup-avail\",\"timestamp\":" + (System.currentTimeMillis() + 1000) + ",\"value\":\"DOWN\"}]";
+        resp = client.post(path: "data", body: jsonData);
+        assertEquals(200, resp.status)
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 10; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH alerts for member triggers, there should still be only 2
+            resp = client.get(path: "",
+                              query: [startTime:start,
+                                      triggerIds:"test-ddgroup-trigger_Source-1,test-ddgroup-trigger_Source-2"] )
+            if ( resp.status == 200 && resp.data != null && resp.data.size > 2) {
+                fail("The disabled trigger should not generate an alert!")
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+
+        // an update to the group conditions should invalidate the data-driven members, and they will need to be
+        // regenerated.
+        AvailabilityCondition updatedFiringCond = new AvailabilityCondition("test-ddgroup-trigger",
+                Mode.FIRING, "test-ddgroup-avail", Operator.DOWN);
+        GroupConditionsInfo groupConditionsInfo = new GroupConditionsInfo( updatedFiringCond, null );
+
+        resp = client.put(path: "triggers/groups/test-ddgroup-trigger/conditions/firing", body: groupConditionsInfo)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // FETCH members, should not be any
+        resp = client.get(path: "triggers/groups/test-ddgroup-trigger/members")
+        assertEquals(200, resp.status)
+        assertEquals(0, resp.data.size)
+
+        resp = client.delete(path: "triggers/groups/test-ddgroup-trigger")
+        assertEquals(200, resp.status)
+    }
+}

--- a/external/src/test/groovy/org/hawkular/alerts/rest/ImportExportITest.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/ImportExportITest.groovy
@@ -1,0 +1,47 @@
+package org.hawkular.alerts.rest
+
+import io.quarkus.test.junit.QuarkusTest
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+
+/**
+ * Import/Export REST tests.
+ *
+ * @author Lucas Ponce
+ */
+@QuarkusTest
+class ImportExportITest extends AbstractQuarkusITestBase {
+
+    @Test
+    void importExportTest() {
+        String basePath = new File(".").canonicalPath
+        String toImport = new File(basePath + "/src/test/resources/import/alerts-data.json").text
+
+        def resp = client.post(path: "import/delete", body: toImport)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "export")
+        assertEquals(200, resp.status)
+
+        // Original definitions from alerts-data.json should be in the backend
+        assertEquals(9, resp.data.triggers.size())
+        assertEquals(1, resp.data.actions.size())
+    }
+
+    @Test
+    void importGroupTest() {
+        String basePath = new File(".").canonicalPath
+        String toImport = new File(basePath + "/src/test/resources/import/groups-data.json").text
+
+        def resp = client.post(path: "import/delete", body: toImport)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "export")
+        assertEquals(200, resp.status)
+
+        assertEquals(3, resp.data.triggers.size())
+    }
+
+
+}

--- a/external/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
@@ -1393,8 +1393,4 @@ class LifecycleITest extends AbstractQuarkusITestBase {
         assertEquals(200, resp.status)
         assertTrue( resp.data.deleted > 0 )
     }
-
-    static void waitDefinitions() {
-        Thread.sleep(100)
-    }
 }

--- a/external/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/LifecycleITest.groovy
@@ -1,0 +1,1400 @@
+package org.hawkular.alerts.rest
+
+import io.quarkus.test.junit.QuarkusTest
+import org.hawkular.alerts.api.model.Severity
+import org.hawkular.alerts.api.model.condition.*
+import org.hawkular.alerts.api.model.data.AvailabilityType
+import org.hawkular.alerts.api.model.data.Data
+import org.hawkular.alerts.api.model.event.Alert
+import org.hawkular.alerts.api.model.trigger.Mode
+import org.hawkular.alerts.api.model.trigger.Trigger
+import org.hawkular.commons.log.MsgLogger
+import org.hawkular.commons.log.MsgLogging
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.TestMethodOrder
+import org.junit.jupiter.api.Test
+
+import static org.hawkular.alerts.api.model.condition.AvailabilityCondition.Operator
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.assertFalse
+import static org.junit.jupiter.api.Assertions.assertNotNull
+import static org.junit.jupiter.api.Assertions.assertNull
+
+/**
+ * Alerts REST tests.
+ *
+ * @author Jay Shaughnessy
+ */
+@TestMethodOrder(MethodOrderer.Alphanumeric.class)
+@QuarkusTest
+class LifecycleITest extends AbstractQuarkusITestBase {
+
+    static MsgLogger logger = MsgLogging.getMsgLogger(LifecycleITest.class)
+
+    static host = System.getProperty('hawkular.host') ?: '127.0.0.1'
+    static port = Integer.valueOf(System.getProperty('hawkular.port') ?: "8081")
+    static t01Start = String.valueOf(System.currentTimeMillis())
+    static t02Start;
+
+    @Test
+    void t01_disableTest() {
+        logger.info( "Running t01_disableTest")
+        String start = t01Start;
+
+        // CREATE the trigger
+        def resp = client.get(path: "")
+        assertEquals(200, resp.status)
+
+        // sub-test: add context and ensure it carries through to the alert
+        Map<String, String> context = new HashMap<>(1);
+        context.put("contextName","contextValue");
+        context.put("contextName2","contextValue2");
+        Trigger testTrigger = new Trigger("test-autodisable-trigger", "test-autodisable-trigger", context);
+
+        // sub-test: add tag and ensure it carries through to the alert
+        testTrigger.addTag("test-autodisable-tname","test-autodisable-tvalue");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/test-autodisable-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setAutoDisable(true);
+        testTrigger.setAutoResolve(false);
+        testTrigger.setSeverity(Severity.LOW);
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing condition
+        AvailabilityCondition firingCond = new AvailabilityCondition("test-autodisable-trigger",
+                Mode.FIRING, "test-autodisable-avail", Operator.NOT_UP);
+
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+        resp = client.put(path: "triggers/test-autodisable-trigger/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-autodisable-trigger",enabled:true])
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-autodisable-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-autodisable-trigger", resp.data.name)
+        assertTrue(resp.data.enabled)
+        assertTrue(resp.data.autoDisable);
+        assertFalse(resp.data.autoEnable);
+        assertEquals("LOW", resp.data.severity);
+        assertNotNull(resp.data.context);
+        assertEquals("contextValue", resp.data.context.get("contextName"));
+        assertEquals("contextValue2", resp.data.context.get("contextName2"));
+
+        // FETCH recent alerts for trigger, should not be any
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autodisable-trigger"] )
+        assertEquals(200, resp.status)
+
+        waitDefinitions()
+
+        // Send in avail data to fire the trigger
+        String jsonData =
+            "[{\"id\":\"test-autodisable-avail\",\"timestamp\":" + 1000 + ",\"value\":\"DOWN\"}]";
+        resp = client.post(path: "data", body: jsonData);
+        assertEquals(200, resp.status)
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 1
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autodisable-trigger"] )
+            if ( resp.status == 200 && resp.data != null && resp.data.size > 0) {
+                if ( i > 10 ) {
+                    logger.info( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        String alertId = resp.data[0].id;
+
+        // FETCH trigger and make sure it's disabled
+        resp = client.get(path: "triggers/test-autodisable-trigger");
+        assertEquals(200, resp.status)
+        Trigger t = (Trigger)resp.data;
+        logger.info(t.toString());
+        assertEquals("test-autodisable-trigger", resp.data.name)
+        assertFalse(resp.data.enabled)
+
+        // RESOLVE manually the alert
+        resp = client.put(path: "resolve", query: [alertIds:alertId,resolvedBy:"testUser",resolvedNotes:"testNotes"] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autodisable-trigger"] )
+        assertEquals(200, resp.status)
+        assertEquals("RESOLVED", resp.data[0].status)
+        assertEquals(2, resp.data[0].lifecycle.size())
+        assertEquals("testUser", resp.data[0].lifecycle[1].user)
+        assertEquals("testNotes", resp.data[0].notes[0].text)
+        assertNull(resp.data[0].resolvedEvalSets)
+        assertNotNull(resp.data[0].trigger.context);
+        Map<String, String> alertContext = (Map<String, String>)resp.data[0].trigger.context;
+        assertEquals("contextValue", alertContext.get("contextName"));
+        assertEquals("contextValue2", alertContext.get("contextName2"));
+
+        // FETCH trigger and make sure it's still disabled, because autoEnable was set to false
+        resp = client.get(path: "triggers/test-autodisable-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-autodisable-trigger", resp.data.name)
+        assertFalse(resp.data.enabled)
+    }
+
+    @Test
+    void t02_autoResolveTest() {
+        logger.info( "Running t02_autoResolveTest")
+        String start = t02Start = String.valueOf(System.currentTimeMillis());
+
+        // CREATE the trigger
+        def resp = client.get(path: "")
+        assertEquals(200, resp.status)
+
+        Trigger testTrigger = new Trigger("test-autoresolve-trigger", "test-autoresolve-trigger");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/test-autoresolve-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setAutoDisable(false);
+        testTrigger.setAutoResolve(true);
+        testTrigger.setAutoResolveAlerts(true);
+        testTrigger.setSeverity(Severity.HIGH);
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing conditions
+        AvailabilityCondition firingCond = new AvailabilityCondition("test-autoresolve-trigger",
+                Mode.FIRING, "test-autoresolve-avail", Operator.NOT_UP);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+        resp = client.put(path: "triggers/test-autoresolve-trigger/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ADD AutoResolve condition
+        AvailabilityCondition autoResolveCond = new AvailabilityCondition("test-autoresolve-trigger",
+                Mode.AUTORESOLVE, "test-autoresolve-avail", Operator.UP);
+
+        conditions.clear();
+        conditions.add( autoResolveCond );
+        resp = client.put(path: "triggers/test-autoresolve-trigger/conditions/autoresolve", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-autoresolve-trigger",enabled:true])
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-autoresolve-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-autoresolve-trigger", resp.data.name)
+        assertTrue(resp.data.enabled)
+        assertFalse(resp.data.autoDisable);
+        assertTrue(resp.data.autoResolve);
+        assertTrue(resp.data.autoResolveAlerts);
+        assertEquals("HIGH", resp.data.severity);
+
+        // FETCH recent alerts for trigger, should not be any
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-trigger"] )
+        assertEquals(200, resp.status)
+
+        waitDefinitions()
+
+        // Send in DOWN avail data to fire the trigger
+        // Instead of going through the bus, in this test we'll use the alerts rest API directly to send data
+        Map<String, String> context = new HashMap<>(1);
+        context.put("contextName","contextValue");
+        Data avail = Data.forAvailability("", "test-autoresolve-avail", 1000 , AvailabilityType.DOWN, context);
+        Collection<Data> datums = new ArrayList<Data>();
+        datums.add(avail);
+        resp = client.post(path: "data", body: datums);
+        assertEquals(200, resp.status)
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 1
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-trigger"] )
+            if ( resp.status == 200 && resp.data.size() == 1 ) {
+                if ( i > 10 ) {
+                    logger.info( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+        assertEquals("HIGH", resp.data[0].severity)
+
+        // ACK the alert
+        resp = client.put(path: "ack", query: [alertIds:resp.data[0].id,ackBy:"testUser",ackNotes:"testNotes"] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "",
+            query: [startTime:start,triggerIds:"test-autoresolve-trigger",statuses:"ACKNOWLEDGED"] )
+        assertEquals(200, resp.status)
+        assertEquals("ACKNOWLEDGED", resp.data[0].status)
+        assertEquals("HIGH", resp.data[0].severity)
+        assertEquals(2, resp.data[0].lifecycle.size())
+        assertEquals("testUser", resp.data[0].lifecycle[1].user)
+        assertEquals("testNotes", resp.data[0].notes[0].text)
+
+        // FETCH trigger and make sure it's still enabled (note - we can't check the mode as that is runtime
+        // info and not supplied in the returned json)
+        resp = client.get(path: "triggers/test-autoresolve-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-autoresolve-trigger", resp.data.name)
+        assertTrue(resp.data.enabled)
+
+        // Send in UP avail data to autoresolve the trigger
+        // Instead of going through the bus, in this test we'll use the alerts rest API directly to send data
+        avail = Data.forAvailability("", "test-autoresolve-avail", 1000, AvailabilityType.UP);
+        datums.clear();
+        datums.add(avail);
+        resp = client.post(path: "data", body: datums);
+        assertEquals(200, resp.status)
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 1
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-trigger",statuses:"RESOLVED"] )
+            if ( resp.status == 200 && resp.data.size() == 1 ) {
+                if ( i > 10 ) {
+                    logger.info( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("RESOLVED", resp.data[0].status)
+        assertEquals(3, resp.data[0].lifecycle.size())
+        assertEquals("AutoResolve", resp.data[0].lifecycle[2].user)
+    }
+
+    @Test
+    void t03_manualResolutionTest() {
+        logger.info( "Running t03_manualResolutionTest")
+        String start = String.valueOf(System.currentTimeMillis());
+
+        // CREATE the trigger
+        def resp = client.get(path: "")
+        assertEquals(200, resp.status)
+
+        Trigger testTrigger = new Trigger("test-manual-trigger", "test-manual-trigger");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/test-manual-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setAutoDisable(false);
+        testTrigger.setAutoResolve(false);
+        testTrigger.setAutoResolveAlerts(false);
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing condition
+        AvailabilityCondition firingCond = new AvailabilityCondition("test-manual-trigger",
+                Mode.FIRING, "test-manual-avail", Operator.NOT_UP);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+        resp = client.put(path: "triggers/test-manual-trigger/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-manual-trigger",enabled:true])
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-manual-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-manual-trigger", resp.data.name)
+        assertTrue(resp.data.enabled)
+        assertFalse(resp.data.autoDisable);
+        assertFalse(resp.data.autoResolve);
+        assertFalse(resp.data.autoResolveAlerts);
+
+        // FETCH recent alerts for trigger, should not be any
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual-trigger"] )
+        assertEquals(200, resp.status)
+
+        waitDefinitions()
+
+        // Send in DOWN avail data to fire the trigger
+        // Instead of going through the bus, in this test we'll use the alerts rest API directly to send data
+        for (int i=1000; i<=5000; i+=1000) {
+            Data avail = Data.forAvailability("", "test-manual-avail", i, AvailabilityType.DOWN);
+            Collection<Data> datums = new ArrayList<>();
+            datums.add(avail);
+            resp = client.post(path: "data", body: datums);
+            assertEquals(200, resp.status)
+        }
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 30; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 5
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual-trigger"] )
+            if ( resp.status == 200 && resp.data.size() == 5 ) {
+                if ( i > 15 ) {
+                    logger.info( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
+                break;
+            }
+        }
+        assertEquals(200, resp.status)
+        assertFalse(resp.data.isEmpty())
+        assertEquals(5, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+
+        // RESOLVE manually the alert
+        resp = client.put(path: "resolve", query: [alertIds:resp.data[0].id,resolvedBy:"testUser",
+                resolvedNotes:"testNotes"] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"OPEN"] )
+        assertEquals(200, resp.status)
+        assertEquals(4, resp.data.size())
+
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"RESOLVED"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+    }
+
+    // Given name ordering this test runs after tests 1..3, it uses the alerts generated in those tests
+    // to test alert queries and updates.
+    @Test
+    void t04_fetchTest() {
+        logger.info( "Running t04_fetchTest")
+        // queries will look for alerts generated in this test tun
+        String start = t01Start;
+
+        // FETCH alerts for bogus trigger, should not be any
+        def resp = client.get(path: "", query: [startTime:start,triggerIds:"XXX"] )
+        assertEquals(200, resp.status)
+        assertTrue(resp.data.isEmpty())
+
+        // FETCH alerts for bogus alert id, should not be any
+        resp = client.get(path: "", query: [startTime:start,alertIds:"XXX,YYY"] )
+        assertEquals(200, resp.status)
+        assertTrue(resp.data.isEmpty())
+
+        // FETCH alerts for bogus name tag, should not be any
+        resp = client.get(path: "", query: [startTime:start,tags:"XXX|*"] )
+        assertEquals(200, resp.status)
+        assertTrue(resp.data.isEmpty())
+
+        // FETCH alerts for bogus name|value tag, should not be any
+        resp = client.get(path: "", query: [startTime:start,tags:"XXX|YYY"] )
+        assertEquals(200, resp.status)
+        assertTrue(resp.data.isEmpty())
+
+        // FETCH alerts for bogus value name/value tag syntax, should fail
+        resp = client.get(path: "", query: [startTime:start,tags:"test-autodisable-tname/test-autodisable-tvalue"] )
+        assertEquals(400, resp.status)
+
+        // FETCH alerts for just triggers generated in test t01, by time, should be 1
+        resp = client.get(path: "", query: [startTime:t01Start,endTime:t02Start] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("test-autodisable-trigger", resp.data[0].trigger.id)
+
+        // FETCH the alert above again, this time by alert id
+        def alertId = resp.data[0].id
+        resp = client.get(path: "", query: [startTime:start,alertIds:"XXX,"+alertId] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals(alertId, resp.data[0].id)
+
+        // FETCH the alert above again, this time by tag
+        resp = client.get(path: "", query: [startTime:start,tags:"test-autodisable-tname|test-autodisable-tvalue"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals(alertId, resp.data[0].id)
+
+        // FETCH the alert above again (fail), with a good triggerId but a bad tag
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autodisable-trigger",tags:"XXX|*"] )
+        assertEquals(200, resp.status)
+        assertEquals(0, resp.data.size())
+
+        // FETCH alerts for test-autoresolve-trigger, there should be 1 from the earlier test, with context data
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-trigger"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertNotNull(resp.data[0].evalSets)
+        assertTrue(!resp.data[0].evalSets.isEmpty())
+        AvailabilityConditionEval eval =
+            (AvailabilityConditionEval)resp.data[0].evalSets.iterator().next().iterator().next();
+        assertNotNull(eval.getContext())
+        assertEquals("contextValue", eval.getContext().get("contextName"))
+
+        // FETCH alerts for test-manual-trigger, there should be 5 from the earlier test
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual-trigger"] )
+        assertEquals(200, resp.status)
+        assertEquals(5, resp.data.size())
+
+        // 4 OPEN and 1 RESOLVED
+        resp = client.get(path: "",
+            query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"OPEN"] )
+        assertEquals(200, resp.status)
+        assertEquals(4, resp.data.size())
+
+        resp = client.get(path: "",
+            query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"RESOLVED"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        resp = client.get(path: "",
+                query: [startResolvedTime:start,triggerIds:"test-manual-trigger"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        resp = client.get(path: "",
+            query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"OPEN,RESOLVED"] )
+        assertEquals(200, resp.status)
+        assertEquals(5, resp.data.size())
+
+        resp = client.get(path: "",
+            query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"OPEN,RESOLVED,ACKNOWLEDGED"] )
+        assertEquals(200, resp.status)
+        assertEquals(5, resp.data.size())
+
+        resp = client.get(path: "",
+            query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"OPEN,ACKNOWLEDGED"] )
+        assertEquals(200, resp.status)
+        assertEquals(4, resp.data.size())
+
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"ACKNOWLEDGED"] )
+        assertEquals(200, resp.status)
+
+        // FETCH by severity (1 HIGH and 1 LOW, five MEDIUM)
+        resp = client.get(path: "", query: [startTime:start,severities:"CRITICAL"] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "", query: [startTime:start,severities:"LOW,HIGH,MEDIUM"] )
+        assertEquals(200, resp.status)
+        assertEquals(7, resp.data.size())
+
+        resp = client.get(path: "", query: [startTime:start,severities:"LOW"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("LOW", resp.data[0].severity)
+        assertEquals("test-autodisable-trigger", resp.data[0].trigger.id)
+
+        resp = client.get(path: "", query: [startTime:start,severities:"HIGH"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("HIGH", resp.data[0].severity)
+        assertEquals("test-autoresolve-trigger", resp.data[0].trigger.id)
+
+        // test thinning as well as verifying the RESOLVED status fetch (using the autoresolve alert)
+        resp = client.get(path: "",
+            query: [startTime:start,triggerIds:"test-autoresolve-trigger",statuses:"RESOLVED",thin:false] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("RESOLVED", resp.data[0].status)
+        assertEquals(3, resp.data[0].lifecycle.size())
+        assertEquals("AutoResolve", resp.data[0].lifecycle[2].user)
+        assertNotNull(resp.data[0].evalSets)
+        assertNotNull(resp.data[0].resolvedEvalSets)
+        assertFalse(resp.data[0].evalSets.isEmpty())
+        assertFalse(resp.data[0].resolvedEvalSets.isEmpty())
+
+        resp = client.get(path: "",
+            query: [startTime:start,triggerIds:"test-autoresolve-trigger",statuses:"RESOLVED",thin:true] )
+        assertEquals(200, resp.status)
+        assertEquals("RESOLVED", resp.data[0].status)
+        assertEquals(3, resp.data[0].lifecycle.size())
+        assertEquals("AutoResolve", resp.data[0].lifecycle[2].user)
+        assertNull(resp.data[0].evalSets)
+        assertNull(resp.data[0].resolvedEvalSets)
+    }
+
+    @Test
+    void t05_paging() {
+        logger.info( "Running t05_paging")
+        // queries will look for alerts generated in this test tun
+        String start = t01Start;
+
+        // 4 OPEN and 1 RESOLVED
+        def resp = client.get(path: "",
+                query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"OPEN,RESOLVED", page: "0", per_page: "3"] )
+        assertEquals(200, resp.status)
+        assertEquals(3, resp.data.size())
+
+        // log.info(resp.headers)
+
+        resp = client.get(path: "",
+                query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"OPEN,RESOLVED", page: "1", per_page: "3"] )
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size())
+
+        // log.info(resp.headers)
+    }
+
+    @Test
+    void t055_tagging() {
+        logger.info( "Running t055_tagging")
+        // queries will look for alerts generated in this test tun
+        String start = t01Start;
+
+        // Fetch the 1 RESOLVED alert and play with its tags
+        def resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual-trigger",statuses:"RESOLVED"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        Alert alert = resp.data[0]
+
+        resp = client.put(path: "tags", query: [alertIds:alert.id,tags:"tag1name|tag1value"] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "", query: [startTime:start,tags:"tag1name|tag1value"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        alert = resp.data[0]
+        assertEquals(1, alert.tags.size())
+        assertEquals("tag1value", alert.tags.get("tag1name"))
+
+        resp = client.delete(path: "tags", query: [alertIds:alert.id,tagNames:"tag1name"] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "", query: [startTime:start,tags:"tag1name|tag1value"] )
+        assertEquals(200, resp.status)
+        assertEquals(0, resp.data.size())
+    }
+
+    @Test
+    void t06_manualAckAndResolutionTest() {
+        logger.info( "Running t06_manualAckAndResolutionTest")
+        String start = String.valueOf(System.currentTimeMillis());
+
+        // CREATE the trigger
+        def resp = client.get(path: "")
+        assertEquals(200, resp.status)
+
+        Trigger testTrigger = new Trigger("test-manual2-trigger", "test-manual2-trigger");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/test-manual2-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setAutoDisable(false);
+        testTrigger.setAutoResolve(false);
+        testTrigger.setAutoResolveAlerts(false);
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing condition
+        AvailabilityCondition firingCond = new AvailabilityCondition("test-manual2-trigger",
+                Mode.FIRING, "test-manual2-avail", Operator.NOT_UP);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+        resp = client.put(path: "triggers/test-manual2-trigger/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-manual2-trigger",enabled:true])
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-manual2-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-manual2-trigger", resp.data.name)
+        assertTrue(resp.data.enabled)
+        assertFalse(resp.data.autoDisable);
+        assertFalse(resp.data.autoResolve);
+        assertFalse(resp.data.autoResolveAlerts);
+
+        // FETCH recent alerts for trigger, should not be any
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual2-trigger"] )
+        assertEquals(200, resp.status)
+
+        waitDefinitions()
+
+        // Send in DOWN avail data to fire the trigger
+        // Instead of going through the bus, in this test we'll use the alerts rest API directly to send data
+        for (int i=1000; i<=5000; i+=1000) {
+            Data avail = Data.forAvailability("", "test-manual2-avail", i, AvailabilityType.DOWN);
+            Collection<Data> datums = new ArrayList<>();
+            datums.add(avail);
+            resp = client.post(path: "data", body: datums);
+            assertEquals(200, resp.status)
+        }
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 30; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 5
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual2-trigger"] )
+            if ( resp.status == 200 && resp.data != null && resp.data.size() == 5 ) {
+                if ( i > 15 ) {
+                    logger.info( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
+                break;
+            }
+        }
+        assertEquals(200, resp.status)
+        assertEquals(5, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+
+        def alertId1 = resp.data[0].id;
+        def alertId2 = resp.data[1].id;
+        // RESOLVE manually 1 alert
+        resp = client.put(path: "resolve/" + alertId1,
+                query: [resolvedBy:"testUser", resolvedNotes:"testNotes"] )
+        assertEquals(200, resp.status)
+
+        resp = client.put(path: "ack/" + alertId2,
+                query: [ackBy:"testUser", ackNotes:"testNotes"] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual2-trigger",statuses:"OPEN"] )
+        assertEquals(200, resp.status)
+        assertEquals(3, resp.data.size())
+
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual2-trigger",statuses:"ACKNOWLEDGED"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        resp = client.get(path: "", query: [startAckTime:start,triggerIds:"test-manual2-trigger"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual2-trigger",statuses:"RESOLVED"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        resp = client.get(path: "", query: [startResolvedTime:start,triggerIds:"test-manual2-trigger"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+    }
+
+    @Test
+    void t07_autoResolveWithThresholdTest() {
+        logger.info( "Running t07_autoResolveWithThresholdTest")
+        String start = String.valueOf(System.currentTimeMillis());
+
+        /*
+            Step 0: Check REST API is up and running
+         */
+        def resp = client.get(path: "")
+        assertEquals(200, resp.status)
+
+        /*
+            Step 1: Remove previous existing definition for this test
+         */
+        resp = client.delete(path: "triggers/test-autoresolve-threshold-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        /*
+            Step 2: Create a new trigger
+         */
+        Trigger testTrigger = new Trigger("test-autoresolve-threshold-trigger", "http://www.myresource.com");
+        testTrigger.setAutoDisable(false);
+        testTrigger.setAutoResolve(true);
+        testTrigger.setAutoResolveAlerts(false);
+        testTrigger.setSeverity(Severity.HIGH);
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        /*
+            Step 3: Create a threshold FIRING condition
+                    Fires when ResponseTime > 100 ms
+                    "Normal" scenario, the condition represents a "bad" situation we want to monitor and alert
+         */
+        ThresholdCondition firingCond = new ThresholdCondition("test-autoresolve-threshold-trigger",
+                Mode.FIRING, "test-autoresolve-threshold", ThresholdCondition.Operator.GT, 100);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+        resp = client.put(path: "triggers/test-autoresolve-threshold-trigger/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        /*
+            Step 4: Create a threshold AUTORESOLVE condition
+                    Fires when ResponseTime <= 100 ms
+                    "Resolution" scenario, the condition represent a "good" situation to enable again "Normal" scenario
+                    Typically it should be the "opposite" than
+         */
+        ThresholdCondition autoResolveCond = new ThresholdCondition("test-autoresolve-threshold-trigger",
+                Mode.AUTORESOLVE, "test-autoresolve-threshold", ThresholdCondition.Operator.LTE, 100);
+
+        conditions.clear();
+        conditions.add( autoResolveCond );
+        resp = client.put(path: "triggers/test-autoresolve-threshold-trigger/conditions/autoresolve", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        /*
+            Step 5: Enable the trigger to accept data
+         */
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-autoresolve-threshold-trigger",enabled:true])
+        assertEquals(200, resp.status)
+
+        /*
+            Step 6: Check trigger is created correctly
+         */
+        resp = client.get(path: "triggers/test-autoresolve-threshold-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("http://www.myresource.com", resp.data.name)
+        assertTrue(resp.data.enabled)
+        assertFalse(resp.data.autoDisable);
+        assertTrue(resp.data.autoResolve);
+        assertFalse(resp.data.autoResolveAlerts);
+        assertEquals("HIGH", resp.data.severity);
+
+        /*
+            Step 7: Check there is not alerts for this trigger at this point
+         */
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-threshold-trigger"] )
+        assertEquals(200, resp.status)
+        assertTrue(resp.data.isEmpty())
+
+        waitDefinitions()
+
+        /*
+            Step 8: Sending "bad" data to fire the trigger
+                    Using direct API instead bus messages
+         */
+        Data responseTime = Data.forNumeric("", "test-autoresolve-threshold", 1000, 101);
+        Collection<Data> datums = new ArrayList<>();
+        datums.add(responseTime);
+        resp = client.post(path: "data", body: datums);
+        assertEquals(200, resp.status)
+
+        /*
+             Step 9: Wait until the engine detects the data, matches the conditions and sends an alert
+         */
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
+
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-threshold-trigger"] )
+            /*
+                We should have only 1 alert
+             */
+            if ( resp.status == 200 && resp.data.size() == 1 ) {
+                if ( i > 10 ) {
+                    logger.info( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+        assertEquals("HIGH", resp.data[0].severity)
+
+        /*
+            Step 10: Sending "bad" data to fire the trigger, should not fire, trigger now in AutoResolve mode
+         */
+        responseTime = Data.forNumeric("", "test-autoresolve-threshold", 2000, 102);
+        datums = new ArrayList<>();
+        datums.add(responseTime);
+        resp = client.post(path: "data", body: datums);
+        assertEquals(200, resp.status)
+
+        /*
+             Step 11: Wait for engine to process data
+                      It should retrieve only 1 data not 2 as previous data shouldn't generate a new alert
+         */
+        Thread.sleep(2500);
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-threshold-trigger"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+        assertEquals("HIGH", resp.data[0].severity)
+
+        /*
+            Step 12: Sending "good" data to change trigger from FIRING to AUTORESOLVE
+         */
+        responseTime = Data.forNumeric("", "test-autoresolve-threshold", 3000, 95);
+        datums = new ArrayList<>();
+        datums.add(responseTime);
+        resp = client.post(path: "data", body: datums);
+        assertEquals(200, resp.status)
+
+        /*
+             Step 13: Wait until the engine detects the data
+                      It should retrieve only 1 data not 2 as previous data shouldn't generate a new alert
+         */
+        Thread.sleep(2500);
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-threshold-trigger"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+        assertEquals("HIGH", resp.data[0].severity)
+
+        /*
+            Step 14: Sending "bad" data to fire the trigger
+         */
+        responseTime = Data.forNumeric("", "test-autoresolve-threshold", 4000, 103);
+        datums = new ArrayList<>();
+        datums.add(responseTime);
+        resp = client.post(path: "data", body: datums);
+        assertEquals(200, resp.status)
+
+        /*
+             Step 15: Wait until the engine detects the data
+                      It should retrieve 2 data
+         */
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
+
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoresolve-threshold-trigger"] )
+            /*
+                We should have only 2 alert
+             */
+            if ( resp.status == 200 && resp.data.size() == 2 ) {
+                if ( i > 10 ) {
+                    logger.info( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+        assertEquals("HIGH", resp.data[0].severity)
+    }
+
+    @Test
+    void t08_autoEnableTest() {
+        logger.info("Running t08_autoEnableTest")
+        String start = String.valueOf(System.currentTimeMillis());
+
+        // CREATE the trigger
+        def resp = client.get(path: "")
+        assertEquals(200, resp.status)
+
+        Trigger testTrigger = new Trigger("test-autoenable-trigger", "test-autoenable-trigger");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/test-autoenable-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setAutoDisable(true);
+        testTrigger.setAutoEnable(true);
+        testTrigger.setAutoResolve(false);
+        testTrigger.setAutoResolveAlerts(false);
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing condition
+        AvailabilityCondition firingCond = new AvailabilityCondition("test-autoenable-trigger",
+                Mode.FIRING, "test-autoenable-avail", Operator.NOT_UP);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+        resp = client.put(path: "triggers/test-autoenable-trigger/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        testTrigger.setEnabled(true);
+
+        resp = client.put(path: "triggers/test-autoenable-trigger", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-autoenable-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-autoenable-trigger", resp.data.name)
+        assertTrue(resp.data.enabled)
+        assertTrue(resp.data.autoDisable);
+        assertTrue(resp.data.autoEnable);
+        assertFalse(resp.data.autoResolve);
+        assertFalse(resp.data.autoResolveAlerts);
+
+        // FETCH recent alerts for trigger, should not be any
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoenable-trigger"] )
+        assertEquals(200, resp.status)
+
+        waitDefinitions()
+
+        // Send in DOWN avail data to fire the trigger
+        // Instead of going through the bus, in this test we'll use the alerts rest API directly to send data
+        for (int i=1000; i<=2000; i+=1000) {
+            Data avail = Data.forAvailability("", "test-autoenable-avail", i, AvailabilityType.DOWN);
+            Collection<Data> datums = new ArrayList<>();
+            datums.add(avail);
+            resp = client.post(path: "data", body: datums);
+            assertEquals(200, resp.status)
+        }
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 1 because the trigger should have disabled after firing
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoenable-trigger"] )
+            if ( resp.status == 200 && resp.data.size() == 1 ) {
+                if ( i > 10 ) {
+                    logger.info( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
+                break;
+            }
+        }
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+
+        // FETCH trigger and make sure it's disabled
+        def resp2 = client.get(path: "triggers/test-autoenable-trigger");
+        assertEquals(200, resp2.status)
+        assertEquals("test-autoenable-trigger", resp2.data.name)
+        assertFalse(resp2.data.enabled)
+
+        // RESOLVE manually the alert
+        resp = client.put(path: "resolve", query: [alertIds:resp.data[0].id,resolvedBy:"testUser",
+                resolvedNotes:"testNotes"] )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoenable-trigger",statuses:"OPEN"] )
+        assertEquals(200, resp.status)
+        assertEquals(0, resp.data.size())
+
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-autoenable-trigger",statuses:"RESOLVED"] )
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // delete any other alerts for the trigger because all alerts for the trigger
+        // must be resolved for autoEnable to kick in...
+        resp = client.put(path: "delete", query: [triggerIds:"test-autoenable-trigger",statuses:"OPEN"] )
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's now enabled
+        resp2 = client.get(path: "triggers/test-autoenable-trigger");
+        assertEquals(200, resp2.status)
+        assertEquals("test-autoenable-trigger", resp2.data.name)
+        assertTrue(resp2.data.enabled)
+    }
+
+    @Test
+    void t09_manualAutoResolveTest() {
+        logger.info("Running t09_manualAutoResolveTest")
+        String start = String.valueOf(System.currentTimeMillis());
+
+        // CREATE the trigger
+        def resp = client.get(path: "")
+        assertEquals(200, resp.status)
+
+        Trigger testTrigger = new Trigger("test-manual-autoresolve-trigger", "test-manual-autoresolve-trigger");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/test-manual-autoresolve-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setAutoDisable(false);
+        testTrigger.setAutoResolve(true);
+        testTrigger.setAutoResolveAlerts(true);
+        testTrigger.setSeverity(Severity.HIGH);
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing condition
+        AvailabilityCondition firingCond = new AvailabilityCondition("test-manual-autoresolve-trigger",
+                Mode.FIRING, "test-manual-autoresolve-avail", Operator.NOT_UP);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+        resp = client.put(path: "triggers/test-manual-autoresolve-trigger/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ADD AutoResolve condition
+        AvailabilityCondition autoResolveCond = new AvailabilityCondition("test-manual-autoresolve-trigger",
+                Mode.AUTORESOLVE, "test-manual-autoresolve-avail", Operator.UP);
+
+        conditions.clear();
+        conditions.add( autoResolveCond );
+        resp = client.put(path: "triggers/test-manual-autoresolve-trigger/conditions/autoresolve", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:"test-manual-autoresolve-trigger",enabled:true])
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-manual-autoresolve-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-manual-autoresolve-trigger", resp.data.name)
+        assertTrue(resp.data.enabled)
+        assertFalse(resp.data.autoDisable);
+        assertFalse(resp.data.autoEnable);
+        assertTrue(resp.data.autoResolve);
+        assertTrue(resp.data.autoResolveAlerts);
+        assertEquals("HIGH", resp.data.severity);
+
+        // FETCH recent alerts for trigger, should not be any
+        resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual-autoresolve-trigger"] )
+        assertEquals(200, resp.status)
+
+        waitDefinitions()
+
+        // Send in DOWN avail data to fire the trigger
+        // Instead of going through the bus, in this test we'll use the alerts rest API directly to send data
+        Data avail = Data.forAvailability("", "test-manual-autoresolve-avail", 1000, AvailabilityType.DOWN);
+        Collection<Data> datums = new ArrayList<>();
+        datums.add(avail);
+        resp = client.post(path: "data", body: datums);
+        assertEquals(200, resp.status)
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 1
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-manual-autoresolve-trigger"] )
+            if ( resp.status == 200 && resp.data.size() == 1 ) {
+                if ( i > 10 ) {
+                    logger.info( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+        assertEquals("HIGH", resp.data[0].severity)
+        String alertId = resp.data[0].id;
+
+        // FETCH trigger and make sure it's still enabled (note - we can't check the mode as that is runtime
+        // info and not supplied in the returned json)
+        resp = client.get(path: "triggers/test-manual-autoresolve-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-manual-autoresolve-trigger", resp.data.name)
+        assertTrue(resp.data.enabled)
+
+        // Manually RESOLVE the alert prior to an autoResolve
+        // At the time of this writing we don't have a service to purge/delete alerts, so for this to work we
+        // have to make sure any old alerts (from prior runs) are also resolved. Because all alerts for the trigger
+        // must be resolved for autoEnable to kick in...
+        resp = client.get(path: "", query: [triggerIds:"test-manual-autoresolve-trigger",statuses:"OPEN"] )
+        assertEquals(200, resp.status)
+        for(int i=0; i < resp.data.size(); ++i) {
+            def resp2 = client.put(path: "resolve", query: [alertIds:resp.data[i].id,resolvedBy:"testUser",
+                resolvedNotes:"testNotes"] )
+            assertEquals(200, resp2.status)
+        }
+
+        // manually resolve the alert again, from here it just ensures that this doesn't create a problem
+        // but examination of the debug log allows us to ensure that this does not cause a reload of the
+        // the trigger into the engine.
+        resp = client.put(path: "resolve", query: [alertIds:alertId,resolvedBy:"testUser", resolvedNotes:"testNotes"] )
+        assertEquals(200, resp.status)
+
+        waitDefinitions()
+
+        // Send in another DOWN data and we should get another alert assuming the trigger was reset to Firing mode
+        avail = Data.forAvailability("", "test-manual-autoresolve-avail", 2000, AvailabilityType.DOWN);
+        datums = new ArrayList<>();
+        datums.add(avail);
+        resp = client.post(path: "data", body: datums);
+        assertEquals(200, resp.status)
+
+        // The alert processing happens async, so give it a little time before failing...
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH recent OPEN alerts for trigger, there should be 1
+            resp = client.get(path: "",
+                query: [startTime:start,triggerIds:"test-manual-autoresolve-trigger",statuses:"OPEN"] )
+            if ( resp.status == 200 && resp.data.size() == 1 ) {
+                if ( i > 10 ) {
+                    logger.info( "Perf: passing but sleep iterations high [" + i + "]" );
+                }
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+    }
+
+    @Test
+    void t10_multiDisable() {
+        def testTriggerIds = "test-autodisable-trigger";
+        testTriggerIds += ",test-autoresolve-trigger";
+        testTriggerIds += ",test-manual-trigger";
+        testTriggerIds += ",test-manual2-trigger";
+        testTriggerIds += ",test-autoresolve-threshold-trigger";
+        testTriggerIds += ",test-autoenable-trigger";
+        testTriggerIds += ",test-manual-autoresolve-trigger";
+        def resp = client.get(path: "triggers", query: [triggerIds:testTriggerIds,thin:true])
+        assert(200 == resp.status)
+
+        def triggerIds = "";
+        def numTriggers = 0;
+        for (int i=0; i < resp.data.size(); ++i) {
+            triggerIds += (( i > 0 ) ? "," : "");
+            triggerIds += resp.data[i].id;
+            ++numTriggers;
+        }
+
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:triggerIds,enabled:false])
+        assert(200 == resp.status)
+
+        resp = client.get(path: "triggers", query: [triggerIds:triggerIds,thin:true])
+        assert(200 == resp.status)
+        assert(numTriggers == resp.data.size())
+
+        for (int i=0; i < resp.data.size(); ++i) {
+            assert(false == resp.data[i].enabled)
+        }
+
+        // test NotFound (nothing should get set true)
+        def badIds = triggerIds + "BOGUS";
+        resp = client.put(path: "triggers/enabled", query: [triggerIds:badIds,enabled:true])
+        assert(404 == resp.status)
+
+        resp = client.get(path: "triggers", query: [triggerIds:triggerIds,thin:true])
+        assert(200 == resp.status)
+        assert(numTriggers == resp.data.size())
+
+        for (int i=0; i < resp.data.size(); ++i) {
+            assert(false == resp.data[i].enabled)
+        }
+    }
+
+    @Test
+    void t11_hwkalerts234Test() {
+        logger.info("Running t10_hwkalerts234Test")
+        String start = String.valueOf(System.currentTimeMillis());
+
+        // CREATE the trigger
+        def resp = client.get(path: "")
+        assertEquals(200, resp.status)
+
+        Trigger testTrigger = new Trigger("test-hwkalerts234-trigger", "test-hwkalerts234-trigger");
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/test-hwkalerts234-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        testTrigger.setAutoResolve(true);
+        testTrigger.setAutoResolveAlerts(true);
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // ADD Firing condition
+        MissingCondition firingCond = new MissingCondition("test-hwkalerts234-trigger",
+                Mode.FIRING, "test-hwkalerts234-avail", 3000);
+
+        Collection<Condition> conditions = new ArrayList<>(1);
+        conditions.add( firingCond );
+        resp = client.put(path: "triggers/test-hwkalerts234-trigger/conditions/firing", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ADD AutoResolve condition
+        AvailabilityCondition autoResolveCond = new AvailabilityCondition("test-hwkalerts234-trigger",
+                Mode.AUTORESOLVE, "test-hwkalerts234-avail", Operator.UP);
+
+        conditions.clear();
+        conditions.add( autoResolveCond );
+        resp = client.put(path: "triggers/test-hwkalerts234-trigger/conditions/autoresolve", body: conditions)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // ENABLE Trigger
+        testTrigger.setEnabled(true);
+
+        resp = client.put(path: "triggers/test-hwkalerts234-trigger", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // FETCH trigger and make sure it's as expected
+        resp = client.get(path: "triggers/test-hwkalerts234-trigger");
+        assertEquals(200, resp.status)
+        assertEquals("test-hwkalerts234-trigger", resp.data.name)
+        assertTrue(resp.data.enabled)
+        assertFalse(resp.data.autoDisable);
+        assertFalse(resp.data.autoEnable);
+        assertTrue(resp.data.autoResolve);
+        assertTrue(resp.data.autoResolveAlerts);
+
+        // This tests that one and only one alert is generated, so let it run for 15s.  This is plenty of time
+        // to ensure we are properly skipping the MissingState check based on the trigger now being in
+        // autoresolve mode (3s missingcondition interval and 2s engine runs)
+        for ( int i=0; i < 30; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 1
+            resp = client.get(path: "", query: [startTime:start,triggerIds:"test-hwkalerts234-trigger"] )
+            if ( resp.status == 200 && resp.data.size() >= 2 ) {
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("OPEN", resp.data[0].status)
+
+        // FETCH trigger and make sure it's still enabled (note - we can't check the mode as that is runtime
+        // info and not supplied in the returned json)
+        resp = client.get(path: "triggers/test-hwkalerts234-trigger");
+        assertEquals(200, resp.status)
+        assertTrue(resp.data.enabled)
+
+        // Send in UP avail and complete the auto-resolve
+        def avail = Data.forAvailability("", "test-hwkalerts234-avail", System.currentTimeMillis(), AvailabilityType.UP);
+        def datums = new ArrayList<>();
+        datums.add(avail);
+        resp = client.post(path: "data", body: datums);
+        assertEquals(200, resp.status)
+
+        // We should see our alert quickly move to RESOLVED
+        for ( int i=0; i < 20; ++i ) {
+            Thread.sleep(500);
+
+            // FETCH recent alerts for trigger, there should be 1
+            resp = client.get(path: "",
+                query: [startTime:start,triggerIds:"test-hwkalerts234-trigger",statuses:"RESOLVED"] )
+            if ( resp.status == 200 && resp.data.size() == 1 ) {
+                logger.info(resp.data);
+                break;
+            }
+            assertEquals(200, resp.status)
+        }
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+        assertEquals("RESOLVED", resp.data[0].status)
+
+        // DISABLE Trigger to stop it from firing again
+        testTrigger.setEnabled(false);
+
+        resp = client.put(path: "triggers/test-hwkalerts234-trigger", body: testTrigger)
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void t99_cleanup() {
+        logger.info("Running t99_cleanup")
+        // clean up triggers
+        def resp = client.delete(path: "triggers/test-autodisable-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-autoresolve-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-manual-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-manual2-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-autoresolve-threshold-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-autoenable-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-manual-autoresolve-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.delete(path: "triggers/test-hwkalerts234-trigger")
+        assert(200 == resp.status || 404 == resp.status)
+
+        // clean up alerts
+
+        resp = client.get(path: "", query: [triggerIds:"test-autodisable-trigger"])
+        assertEquals(200, resp.status)
+        assertFalse( resp.data.isEmpty() )
+
+        def resp2;
+        for(int i=0; i < resp.data.size(); ++i) {
+            // test single alert get
+            resp2 = client.get(path: "alert/" + resp.data[i].id )
+            assertEquals(200, resp2.status)
+            // test single alert delete
+            def resp3 = client.delete(path: resp.data[i].id )
+            assertEquals(200, resp3.status)
+        }
+        // test failed single alert get
+        resp = client.get(path: "alert/" + resp2.data.id )
+        assertEquals(404, resp.status)
+        // test failed single alert delete
+        resp = client.delete(path: resp2.data.id )
+        assertEquals(404, resp.status)
+
+        // test empty multi-alert delete
+        resp = client.put(path: "delete", query: [triggerIds:"test-autodisable-trigger"])
+        assertEquals(200, resp.status)
+        assertEquals( 0, resp.data.deleted )
+
+        // test success multi-alert delete
+        resp = client.put(path: "delete", query: [triggerIds:"test-autoresolve-trigger"])
+        assertEquals(200, resp.status)
+        assertTrue( resp.data.deleted > 0 )
+
+        resp = client.put(path: "delete", query: [triggerIds:"test-manual-trigger"])
+        assertEquals(200, resp.status)
+        assertTrue( resp.data.deleted > 0 )
+
+        resp = client.put(path: "delete", query: [triggerIds:"test-manual2-trigger"])
+        assertEquals(200, resp.status)
+        assertTrue( resp.data.deleted > 0 )
+
+        resp = client.put(path: "delete", query: [triggerIds:"test-autoresolve-threshold-trigger"])
+        assertEquals(200, resp.status)
+        assertTrue( resp.data.deleted > 0 )
+
+        resp = client.put(path: "delete", query: [triggerIds:"test-autoenable-trigger"])
+        assertEquals(200, resp.status)
+        assertTrue( resp.data.deleted > 0 )
+
+        resp = client.put(path: "delete", query: [triggerIds:"test-manual-autoresolve-trigger"])
+        assertEquals(200, resp.status)
+        assertTrue( resp.data.deleted > 0 )
+
+        resp = client.put(path: "delete", query: [triggerIds:"test-hwkalerts234-trigger"])
+        assertEquals(200, resp.status)
+        assertTrue( resp.data.deleted > 0 )
+    }
+
+    static void waitDefinitions() {
+        Thread.sleep(100)
+    }
+}

--- a/external/src/test/groovy/org/hawkular/alerts/rest/TriggersITest.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/TriggersITest.groovy
@@ -1,0 +1,860 @@
+package org.hawkular.alerts.rest
+
+import io.quarkus.test.junit.QuarkusTest
+import org.hawkular.alerts.api.json.GroupConditionsInfo
+import org.hawkular.alerts.api.json.GroupMemberInfo
+import org.hawkular.alerts.api.json.UnorphanMemberInfo
+import org.hawkular.alerts.api.model.Severity
+import org.hawkular.alerts.api.model.action.ActionDefinition
+import org.hawkular.alerts.api.model.condition.Condition
+import org.hawkular.alerts.api.model.condition.ThresholdCondition
+import org.hawkular.alerts.api.model.dampening.Dampening
+import org.hawkular.alerts.api.model.trigger.Mode
+import org.hawkular.alerts.api.model.trigger.Trigger
+import org.hawkular.commons.log.MsgLogger
+import org.hawkular.commons.log.MsgLogging
+import org.junit.jupiter.api.Test
+
+import static org.junit.jupiter.api.Assertions.assertEquals
+import static org.junit.jupiter.api.Assertions.assertTrue
+import static org.junit.jupiter.api.Assertions.assertNotNull
+
+/**
+ * Triggers REST tests.
+ *
+ * @author Lucas Ponce
+ */
+@QuarkusTest
+class TriggersITest extends AbstractQuarkusITestBase {
+
+    static MsgLogger logger = MsgLogging.getMsgLogger(TriggersITest.class)
+
+    @Test
+    void createTrigger() {
+        Trigger testTrigger = new Trigger("test-trigger-1", "No-Metric");
+
+        // remove if it exists
+        def resp = client.delete(path: "triggers/test-trigger-1")
+        assert(200 == resp.status || 404 == resp.status)
+
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // Should not be able to create the same triggerId again
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(400, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-1");
+        assertEquals(200, resp.status)
+        assertEquals("No-Metric", resp.data.name)
+
+        testTrigger.setName("No-Metric-Modified")
+        testTrigger.setSeverity(Severity.CRITICAL)
+        resp = client.put(path: "triggers/test-trigger-1", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/test-trigger-1")
+        assertEquals(200, resp.status)
+        assertEquals("No-Metric-Modified", resp.data.name)
+        assertEquals("CRITICAL", resp.data.severity)
+
+        resp = client.delete(path: "triggers/test-trigger-1")
+        assertEquals(200, resp.status)
+
+        // Test create w/o assigning a TriggerId, it should generate a UUID
+        testTrigger.setId(null);
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+        assertNotNull(resp.data.id)
+
+        // Delete the trigger
+        resp = client.delete(path: "triggers/" + resp.data.id)
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void testGroupTrigger() {
+        Trigger groupTrigger = new Trigger("group-trigger", "group-trigger");
+        groupTrigger.setEnabled(false);
+
+        // remove if it exists
+        def resp = client.delete(path: "triggers/groups/group-trigger", query: [keepNonOrphans:false,keepOrphans:false])
+        assert(200 == resp.status || 404 == resp.status)
+
+        // create the group
+        resp = client.post(path: "triggers/groups", body: groupTrigger)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/group-trigger")
+        assertEquals(200, resp.status)
+        groupTrigger = (Trigger)resp.data;
+        assertEquals( true, groupTrigger.isGroup() );
+
+        ThresholdCondition cond1 = new ThresholdCondition("group-trigger", Mode.FIRING, "DataId1-Token",
+            ThresholdCondition.Operator.GT, 10.0);
+        Map<String, Map<String, String>> dataIdMemberMap = new HashMap<>();
+        GroupConditionsInfo groupConditionsInfo = new GroupConditionsInfo( cond1, dataIdMemberMap );
+
+        resp = client.put(path: "triggers/groups/group-trigger/conditions/firing", body: groupConditionsInfo)
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size())
+
+        // create member 1
+        Map<String, String> dataId1Map = new HashMap<>(2);
+        dataId1Map.put("DataId1-Token", "DataId1-Child1");
+        GroupMemberInfo groupMemberInfo = new GroupMemberInfo("group-trigger", "member1", "member1", null, null, null,
+            dataId1Map);
+        resp = client.post(path: "triggers/groups/members", body: groupMemberInfo);
+        assertEquals(200, resp.status)
+
+        // create member 2
+        dataId1Map.put("DataId1-Token", "DataId1-Child2");
+        groupMemberInfo = new GroupMemberInfo("group-trigger", "member2", "member2", null, null, null, dataId1Map);
+        resp = client.post(path: "triggers/groups/members", body: groupMemberInfo);
+        assertEquals(200, resp.status)
+
+        // orphan member2, it should no longer get updates
+        resp = client.put(path: "triggers/groups/members/member2/orphan");
+        assertEquals(200, resp.status)
+
+        // add dampening to the group
+        Dampening groupDampening = Dampening.forRelaxedCount("", "group-trigger", Mode.FIRING, 2, 4);
+        resp = client.post(path: "triggers/groups/group-trigger/dampenings", body: groupDampening);
+        assertEquals(200, resp.status)
+        groupDampening = resp.data // get the updated dampeningId for use below
+
+        // add tag to the group (via update)
+        groupTrigger.addTag( "group-tname", "group-tvalue" );
+        resp = client.put(path: "triggers/groups/group-trigger", body: groupTrigger)
+        assertEquals(200, resp.status)
+
+        // add another condition to the group (only member1 is relevant, member2 is now an orphan)
+        ThresholdCondition cond2 = new ThresholdCondition("group-trigger", Mode.FIRING, "DataId2-Token",
+            ThresholdCondition.Operator.LT, 20.0);
+        dataId1Map.clear();
+        dataId1Map.put("member1", "DataId1-Child1");
+        Map<String, String> dataId2Map = new HashMap<>(2);
+        dataId2Map.put("member1", "DataId2-Child1");
+        dataIdMemberMap.put("DataId1-Token", dataId1Map);
+        dataIdMemberMap.put("DataId2-Token", dataId2Map);
+        Collection<Condition> groupConditions = new ArrayList<>(2);
+        groupConditions.add(cond1);
+        groupConditions.add(cond2);
+        groupConditionsInfo = new GroupConditionsInfo(groupConditions, dataIdMemberMap);
+        resp = client.put(path: "triggers/groups/group-trigger/conditions/firing", body: groupConditionsInfo)
+        assertEquals(200, resp.status)
+
+        // update the group trigger
+        groupTrigger.setAutoDisable( true );
+        resp = client.put(path: "triggers/groups/group-trigger", body: groupTrigger)
+        assertEquals(200, resp.status)
+
+        // update the group dampening to the group
+        String did = groupDampening.getDampeningId();
+        groupDampening = Dampening.forRelaxedCount("", "group-trigger", Mode.FIRING, 2, 6);
+        resp = client.put(path: "triggers/groups/group-trigger/dampenings/" + did, body: groupDampening);
+        assertEquals(200, resp.status)
+
+        // query w/o orphans
+        resp = client.get(path: "triggers/groups/group-trigger/members", query: [includeOrphans:"false"])
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size());
+        Trigger member = (Trigger)resp.data[0];
+        assertEquals( false, member.isOrphan() );
+        assertEquals( "member1", member.getName() );
+
+        // query w orphans
+        resp = client.get(path: "triggers/groups/group-trigger/members", query: [includeOrphans:"true"])
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size());
+        member = (Trigger)resp.data[0];
+        Trigger orphanMember = (Trigger)resp.data[1];
+        if ( member.isOrphan() ) {
+            member = (Trigger)resp.data[1];
+            orphanMember = (Trigger)resp.data[0];
+        }
+        assertEquals( "member1", member.getName() );
+        assertEquals( false, member.isOrphan() );
+        assertEquals( true, member.isAutoDisable());
+        assertEquals( "member2", orphanMember.getName() );
+        assertEquals( true, orphanMember.isOrphan() );
+        assertEquals( false, orphanMember.isAutoDisable());
+
+        // get the group trigger
+        resp = client.get(path: "triggers/group-trigger")
+        assertEquals(200, resp.status)
+        groupTrigger = (Trigger)resp.data;
+        assertEquals( "group-trigger", groupTrigger.getName() );
+        assertEquals( true, groupTrigger.isGroup() );
+        assertEquals( true, groupTrigger.isAutoDisable());
+
+        // get the group dampening
+        resp = client.get(path: "triggers/group-trigger/dampenings")
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size());
+
+        // check the group tags
+        Map<String, String> groupTags = groupTrigger.getTags();
+        assertEquals(1, groupTags.size());
+        assertEquals("group-tvalue", groupTags.get("group-tname"));
+
+        // get the group conditions
+        resp = client.get(path: "triggers/group-trigger/conditions")
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size());
+        groupConditions = (Collection<Condition>)resp.data;
+        Set<String> conditionDataIds = new HashSet<>();
+        conditionDataIds.add(((ThresholdCondition) resp.data[0]).getDataId())
+        conditionDataIds.add(((ThresholdCondition) resp.data[1]).getDataId())
+        assertTrue(conditionDataIds.contains("DataId1-Token"))
+        assertTrue(conditionDataIds.contains("DataId2-Token"))
+
+        // get the member1 trigger
+        resp = client.get(path: "triggers/member1")
+        assertEquals(200, resp.status)
+        def member1 = (Trigger)resp.data;
+        assertEquals( "member1", member1.getName() );
+        assertEquals( true, member1.isMember() );
+        assertEquals( true, member1.isAutoDisable());
+
+        // check the member1 tag
+        Map<String, String> memberTags = member1.getTags();
+        assertEquals(1, memberTags.size());
+        assertEquals("group-tvalue", memberTags.get("group-tname"));
+
+        // get the member1 dampening
+        resp = client.get(path: "triggers/member1/dampenings")
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size());
+
+        // get the member1 conditions
+        resp = client.get(path: "triggers/member1/conditions")
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size());
+
+        // get the member2 trigger
+        resp = client.get(path: "triggers/member2")
+        assertEquals(200, resp.status)
+        def member2 = (Trigger)resp.data;
+        assertEquals( "member2", member2.getName() );
+        assertEquals( true, member2.isMember() );
+        assertEquals( false, member2.isAutoDisable());
+
+        // check the member2 tag
+        memberTags = member2.getTags();
+        assertEquals(0, memberTags.size());
+
+        // check the member2 dampening
+        resp = client.get(path: "triggers/member2/dampenings")
+        assertEquals(200, resp.status)
+        assertEquals(0, resp.data.size());
+
+        // get the member2 condition
+        resp = client.get(path: "triggers/member2/conditions")
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size());
+
+        // unorphan member2
+        Map<String, String> dataIdMap = new HashMap<>(2);
+        dataIdMap.put("DataId1-Token", "DataId1-Child2");
+        dataIdMap.put("DataId2-Token", "DataId2-Child2");
+        UnorphanMemberInfo unorphanMemberInfo = new UnorphanMemberInfo(null, null, dataIdMap);
+        resp = client.put(path: "triggers/groups/members/member2/unorphan", body: unorphanMemberInfo);
+        assertEquals(200, resp.status)
+
+        // get the member2 trigger
+        resp = client.get(path: "triggers/member2")
+        assertEquals(200, resp.status)
+        member2 = (Trigger)resp.data;
+        assertEquals( "member2", member2.getName() );
+        assertEquals( false, member2.isOrphan() );
+        assertEquals( true, member2.isAutoDisable());
+
+        // check the member2 tag
+        memberTags = member2.getTags();
+        assertEquals(1, memberTags.size());
+        assertEquals("group-tvalue", memberTags.get("group-tname"));
+
+        // check the member2 dampening
+        resp = client.get(path: "triggers/member2/dampenings")
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size());
+
+        // get the member2 condition
+        resp = client.get(path: "triggers/member2/conditions")
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size());
+
+        // delete group tag
+        groupTrigger.getTags().clear();
+        resp = client.put(path: "triggers/groups/group-trigger", body: groupTrigger)
+        assertEquals(200, resp.status)
+
+        // delete group dampening
+        resp = client.delete(path: "triggers/groups/group-trigger/dampenings/" + did)
+        assertEquals(200, resp.status)
+
+        // delete group cond1 (done by re-setting conditions w/o the undesired condition)
+        groupConditions.clear();
+        groupConditions.add(cond2);
+        logger.info(groupConditions.toString())
+        assertEquals(1, groupConditions.size());
+        dataId2Map.clear();
+        dataId2Map.put("member1", "DataId2-Child1");
+        dataId2Map.put("member2", "DataId2-Child2");
+        dataIdMemberMap.clear();
+        dataIdMemberMap.put("DataId2-Token", dataId2Map);
+        groupConditionsInfo = new GroupConditionsInfo(groupConditions, dataIdMemberMap);
+        resp = client.put(path: "triggers/groups/group-trigger/conditions/firing", body: groupConditionsInfo)
+        assertEquals(200, resp.status)
+
+        // get the group trigger
+        resp = client.get(path: "triggers/group-trigger")
+        assertEquals(200, resp.status)
+        groupTrigger = (Trigger)resp.data;
+        assertEquals( "group-trigger", groupTrigger.getName() );
+        assertEquals( true, groupTrigger.isGroup() );
+        assertEquals( true, groupTrigger.isAutoDisable());
+
+        // check the group dampening
+        groupTags = groupTrigger.getTags();
+        assertEquals(0, groupTags.size());
+
+        // check the group condition
+        resp = client.get(path: "triggers/group-trigger/conditions")
+        assertEquals(200, resp.status)
+        assertEquals(1, resp.data.size());
+
+        // query w/o orphans
+        resp = client.get(path: "triggers/groups/group-trigger/members", query: [includeOrphans:"false"])
+        assertEquals(200, resp.status)
+        assertEquals(2, resp.data.size());
+        for(int i=0; i < resp.data.size(); ++i) {
+            member = (Trigger)resp.data[i];
+            String name = member.getName();
+            assertEquals( false, member.isOrphan() );
+            assertEquals( true, member.isAutoDisable());
+            resp = client.get(path: "triggers/" + name + "/dampenings")
+            assertEquals(200, resp.status)
+            assertEquals(0, resp.data.size());
+            resp = client.get(path: "triggers/" + name + "/conditions")
+            assertEquals(200, resp.status)
+            assertEquals(1, resp.data.size());
+        }
+
+        // ensure a member trigger can be removed with the standard remove trigger
+        resp = client.delete(path: "triggers/member2")
+        assertEquals(200, resp.status)
+        resp = client.get(path: "triggers/member2")
+        assertEquals(404, resp.status)
+
+        // ensure a group trigger can not be removed with the standard remove trigger
+        resp = client.delete(path: "triggers/group-trigger")
+        assertEquals(400, resp.status) // Changed here as it should return a 400 due is a bad argument, not an internal problem
+
+        // remove group trigger
+        resp = client.delete(path: "triggers/groups/group-trigger")
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/group-trigger")
+        assertEquals(404, resp.status)
+        resp = client.get(path: "triggers/member1")
+        assertEquals(404, resp.status)
+        resp = client.get(path: "triggers/member2")
+        assertEquals(404, resp.status)
+    }
+
+    @Test
+    void testTag() {
+        Trigger testTrigger = new Trigger("test-trigger-1", "No-Metric");
+        testTrigger.addTag("tname", "tvalue");
+
+        // remove if it exists
+        def resp = client.delete(path: "triggers/test-trigger-1")
+        assert(200 == resp.status || 404 == resp.status)
+
+        // create the test trigger
+        resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        // make sure the test trigger exists
+        resp = client.get(path: "triggers/test-trigger-1");
+        assertEquals(200, resp.status)
+        assertEquals("No-Metric", resp.data.name)
+
+        Map<String, String> tags = resp.data.tags;
+        assertEquals("tvalue", tags.get("tname"));
+
+        resp = client.get(path: "triggers", query: [tags:"tname|tvalue"] );
+        assertEquals(200, resp.status)
+        assertEquals("test-trigger-1", resp.data.iterator().next().id)
+
+        resp = client.get(path: "triggers", query: [tags:"tname|*"] );
+        assertEquals(200, resp.status)
+        assertEquals("test-trigger-1", resp.data.iterator().next().id)
+
+        resp = client.get(path: "triggers", query: [tags:"funky|funky"] );
+        assertEquals(200, resp.status)
+        assertEquals(false, resp.data.iterator().hasNext())
+
+        // delete the tag
+        testTrigger.getTags().clear();
+        resp = client.put(path: "triggers/test-trigger-1", body: testTrigger )
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers", query: [tags:"tname|tvalue"] );
+        assertEquals(200, resp.status)
+        assertEquals(0, resp.data.size())
+
+        // delete the trigger
+        resp = client.delete(path: "triggers/test-trigger-1")
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void createFullTrigger() {
+        // CREATE the action definition
+        String actionPlugin = "email"
+        String actionId = "email-to-admin";
+
+        Map<String, String> actionProperties = new HashMap<>();
+//        actionProperties.put("from", "from-alerts@company.org");
+        actionProperties.put("to", "to-admin@company.org");
+//        actionProperties.put("cc", "cc-developers@company.org");
+
+        ActionDefinition actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+
+        def resp = client.post(path: "actions", body: actionDefinition)
+        assert(200 == resp.status || 400 == resp.status)
+
+        String jsonTrigger = "{\n" +
+                "      \"trigger\":{\n" +
+                "        \"id\": \"full-test-trigger-1\",\n" +
+                "        \"enabled\": true,\n" +
+                "        \"name\": \"NumericData-01-low\",\n" +
+                "        \"description\": \"description 1\",\n" +
+                "        \"severity\": \"HIGH\",\n" +
+                "        \"actions\": [\n" +
+                "          {\"actionPlugin\":\"email\", \"actionId\":\"email-to-admin\"}\n" +
+                "        ],\n" +
+                "        \"context\": {\n" +
+                "          \"name1\":\"value1\"\n" +
+                "        },\n" +
+                "        \"tags\": {\n" +
+                "          \"tname1\":\"tvalue1\",\n" +
+                "          \"tname2\":\"tvalue2\"\n" +
+                "        }\n" +
+                "      },\n" +
+                "      \"dampenings\":[\n" +
+                "        {\n" +
+                "          \"triggerMode\": \"FIRING\",\n" +
+                "          \"type\": \"STRICT\",\n" +
+                "          \"evalTrueSetting\": 2,\n" +
+                "          \"evalTotalSetting\": 2\n" +
+                "        }\n" +
+                "      ],\n" +
+                "      \"conditions\":[\n" +
+                "        {\n" +
+                "          \"triggerMode\": \"FIRING\",\n" +
+                "          \"type\": \"threshold\",\n" +
+                "          \"dataId\": \"NumericData-01\",\n" +
+                "          \"operator\": \"LT\",\n" +
+                "          \"threshold\": 10.0,\n" +
+                "          \"context\": {\n" +
+                "            \"description\": \"Response Time\",\n" +
+                "            \"unit\": \"ms\"\n" +
+                "          }\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }";
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/full-test-trigger-1")
+        assert(200 == resp.status || 404 == resp.status)
+
+        // create the test trigger
+        resp = client.post(path: "triggers/trigger", body: jsonTrigger)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/trigger/full-test-trigger-1");
+        assertEquals(200, resp.status)
+        assertEquals("NumericData-01-low", resp.data.trigger.name)
+        assertEquals(testTenant, resp.data.trigger.tenantId)
+        assertEquals(1, resp.data.dampenings.size())
+        assertEquals(1, resp.data.conditions.size())
+
+        resp = client.delete(path: "triggers/full-test-trigger-1")
+        assertEquals(200, resp.status)
+
+        resp = client.delete(path: "actions/" + actionPlugin + "/" + actionId)
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void createFullTriggerWithNullValues() {
+        String jsonTrigger = "{\n" +
+                "      \"trigger\":{\n" +
+                "        \"id\": \"full-test-trigger-with-nulls\",\n" +
+                "        \"enabled\": true,\n" +
+                "        \"name\": \"NumericData-01-low\",\n" +
+                "        \"description\": \"description 1\",\n" +
+                "        \"severity\": null\n," +
+                "        \"autoResolve\": null\n," +
+                "        \"autoResolveAlerts\": null\n," +
+                "        \"eventType\": null\n," +
+                "        \"tenantId\": null\n," +
+                "        \"description\": null\n," +
+                "        \"autoEnable\": null\n," +
+                "        \"autoDisable\": null\n" +
+                "      }\n" +
+                "    }";
+
+        // remove if it exists
+        def resp = client.delete(path: "triggers/full-test-trigger-with-nulls")
+        assert(200 == resp.status || 404 == resp.status)
+
+        // create the test trigger
+        resp = client.post(path: "triggers/trigger", body: jsonTrigger)
+        assertEquals(200, resp.status)
+
+        resp = client.delete(path: "triggers/full-test-trigger-with-nulls")
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void updateFullTrigger() {
+        // CREATE the action definition
+        String actionPlugin = "email"
+        String actionId = "email-to-admin";
+
+        Map<String, String> actionProperties = new HashMap<>();
+        actionProperties.put("from", "from-alerts@company.org");
+        actionProperties.put("to", "to-admin@company.org");
+        actionProperties.put("cc", "cc-developers@company.org");
+
+        ActionDefinition actionDefinition = new ActionDefinition(null, actionPlugin, actionId, actionProperties);
+
+        def resp = client.post(path: "actions", body: actionDefinition)
+        assert(200 == resp.status || 400 == resp.status)
+
+        String jsonTrigger = "{\n" +
+                "      \"trigger\":{\n" +
+                "        \"id\": \"full-test-trigger-1\",\n" +
+                "        \"enabled\": true,\n" +
+                "        \"name\": \"NumericData-01-low\",\n" +
+                "        \"description\": \"description 1\",\n" +
+                "        \"severity\": \"HIGH\",\n" +
+                "        \"actions\": [\n" +
+                "          {\"actionPlugin\":\"email\", \"actionId\":\"email-to-admin\"}\n" +
+                "        ],\n" +
+                "        \"context\": {\n" +
+                "          \"name1\":\"value1\"\n" +
+                "        },\n" +
+                "        \"tags\": {\n" +
+                "          \"tname1\":\"tvalue1\",\n" +
+                "          \"tname2\":\"tvalue2\"\n" +
+                "        }\n" +
+                "      },\n" +
+                "      \"dampenings\":[\n" +
+                "        {\n" +
+                "          \"triggerMode\": \"FIRING\",\n" +
+                "          \"type\": \"STRICT\",\n" +
+                "          \"evalTrueSetting\": 2,\n" +
+                "          \"evalTotalSetting\": 2\n" +
+                "        }\n" +
+                "      ],\n" +
+                "      \"conditions\":[\n" +
+                "        {\n" +
+                "          \"triggerMode\": \"FIRING\",\n" +
+                "          \"type\": \"threshold\",\n" +
+                "          \"dataId\": \"NumericData-01\",\n" +
+                "          \"operator\": \"LT\",\n" +
+                "          \"threshold\": 10.0,\n" +
+                "          \"context\": {\n" +
+                "            \"description\": \"Response Time\",\n" +
+                "            \"unit\": \"ms\"\n" +
+                "          }\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }";
+
+        // remove if it exists
+        resp = client.delete(path: "triggers/full-test-trigger-1")
+        assert(200 == resp.status || 404 == resp.status)
+
+        // create the test trigger
+        resp = client.post(path: "triggers/trigger", body: jsonTrigger)
+        assertEquals(200, resp.status)
+
+        // get the test trigger
+        resp = client.get(path: "triggers/trigger/full-test-trigger-1");
+        assertEquals(200, resp.status)
+        assertEquals("NumericData-01-low", resp.data.trigger.name)
+        assertEquals("description 1", resp.data.trigger.description)
+        assertEquals(true, resp.data.trigger.enabled)
+        assertEquals(testTenant, resp.data.trigger.tenantId)
+        assertEquals(1, resp.data.dampenings.size())
+        assertEquals(1, resp.data.conditions.size())
+
+        // try to update with null trigger
+        def fullTrigger = resp.data;
+        def trigger = fullTrigger.trigger;
+        fullTrigger.trigger = null;
+        resp = client.put(path: "triggers/trigger/full-test-trigger-1", body: fullTrigger)
+        assertEquals(400, resp.status)
+        fullTrigger.trigger = trigger;
+
+        // try to update trigger type
+        trigger.type = 'GROUP';
+        resp = client.put(path: "triggers/trigger/full-test-trigger-1", body: fullTrigger)
+        assertEquals(400, resp.status)
+        trigger.type = 'STANDARD';
+
+        // try an update with no changes (should succeed but not actually perform any updates, need to manually verify)
+        resp = client.put(path: "triggers/trigger/full-test-trigger-1", body: fullTrigger)
+        assertEquals(200, resp.status)
+
+        // re-get the test trigger
+        def prevFullTrigger = fullTrigger;
+        resp = client.get(path: "triggers/trigger/full-test-trigger-1");
+        assertEquals(200, resp.status)
+        fullTrigger = resp.data;
+        assertEquals(prevFullTrigger, fullTrigger);
+
+        // try an update with changes
+        trigger = fullTrigger.trigger;
+        trigger.description = "updated description";
+        trigger.enabled = false;
+        resp = client.put(path: "triggers/trigger/full-test-trigger-1", body: fullTrigger)
+        assertEquals(200, resp.status)
+
+        // re-get the test trigger
+        resp = client.get(path: "triggers/trigger/full-test-trigger-1");
+        assertEquals(200, resp.status)
+        fullTrigger = resp.data;
+        trigger = fullTrigger.trigger;
+        assertEquals("updated description", trigger.description)
+        assertEquals(false, trigger.enabled)
+
+        // try an update that removes the dampening and condition set
+        fullTrigger.dampenings = null;
+        fullTrigger.conditions = null;
+        resp = client.put(path: "triggers/trigger/full-test-trigger-1", body: fullTrigger)
+        assertEquals(200, resp.status)
+
+        // re-get the test trigger
+        resp = client.get(path: "triggers/trigger/full-test-trigger-1");
+        assertEquals(200, resp.status)
+        fullTrigger = resp.data;
+        assertEquals(null, fullTrigger.dampenings);
+        assertEquals(null, fullTrigger.conditions);
+
+        // add back dampening
+        fullTrigger.dampenings = "[\n" +
+                "        {\n" +
+                "          \"triggerMode\": \"FIRING\",\n" +
+                "          \"type\": \"STRICT\",\n" +
+                "          \"evalTrueSetting\": 2,\n" +
+                "          \"evalTotalSetting\": 2\n" +
+                "        }]";
+        resp = client.put(path: "triggers/trigger/full-test-trigger-1", body: fullTrigger)
+        assertEquals(200, resp.status)
+
+        // re-get the test trigger
+        resp = client.get(path: "triggers/trigger/full-test-trigger-1");
+        assertEquals(200, resp.status)
+        fullTrigger = resp.data;
+        assertTrue(null != fullTrigger.dampenings);
+        assertEquals(1, fullTrigger.dampenings.size());
+        assertEquals("STRICT", fullTrigger.dampenings[0].type);
+
+        // add back condition
+        fullTrigger.conditions = "[\n" +
+                "        {\n" +
+                "          \"triggerMode\": \"FIRING\",\n" +
+                "          \"type\": \"threshold\",\n" +
+                "          \"dataId\": \"NumericData-01\",\n" +
+                "          \"operator\": \"LT\",\n" +
+                "          \"threshold\": 10.0,\n" +
+                "          \"context\": {\n" +
+                "            \"description\": \"Response Time\",\n" +
+                "            \"unit\": \"ms\"\n" +
+                "          }\n" +
+                "        }]";
+        resp = client.put(path: "triggers/trigger/full-test-trigger-1", body: fullTrigger)
+        assertEquals(200, resp.status)
+
+        // re-get the test trigger
+        resp = client.get(path: "triggers/trigger/full-test-trigger-1");
+        assertEquals(200, resp.status)
+        fullTrigger = resp.data;
+        assertTrue(null != fullTrigger.conditions);
+        assertEquals(1, fullTrigger.conditions.size());
+        assertEquals("THRESHOLD", fullTrigger.conditions[0].type);
+
+        // remove the test trigger
+        resp = client.delete(path: "triggers/full-test-trigger-1")
+        assertEquals(200, resp.status)
+
+        resp = client.delete(path: "actions/" + actionPlugin + "/" + actionId)
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void failWithUnknownActionOrPluginFullTrigger() {
+        String jsonTrigger = "{\n" +
+                "      \"trigger\":{\n" +
+                "        \"id\": \"full-test-trigger-1\",\n" +
+                "        \"enabled\": true,\n" +
+                "        \"name\": \"NumericData-01-low\",\n" +
+                "        \"description\": \"description 1\",\n" +
+                "        \"severity\": \"HIGH\",\n" +
+                "        \"actions\": [\n" +
+                // Unknown email-to-nothing action
+                "          {\"actionPlugin\":\"email\", \"actionId\":\"email-to-nothing\"}\n" +
+                "        ],\n" +
+                "        \"context\": {\n" +
+                "          \"name1\":\"value1\"\n" +
+                "        },\n" +
+                "        \"tags\": {\n" +
+                "          \"tname1\":\"tvalue1\",\n" +
+                "          \"tname2\":\"tvalue2\"\n" +
+                "        }\n" +
+                "      },\n" +
+                "      \"dampenings\":[\n" +
+                "        {\n" +
+                "          \"triggerMode\": \"FIRING\",\n" +
+                "          \"type\": \"STRICT\",\n" +
+                "          \"evalTrueSetting\": 2,\n" +
+                "          \"evalTotalSetting\": 2\n" +
+                "        }\n" +
+                "      ],\n" +
+                "      \"conditions\":[\n" +
+                "        {\n" +
+                "          \"triggerMode\": \"FIRING\",\n" +
+                "          \"type\": \"threshold\",\n" +
+                "          \"dataId\": \"NumericData-01\",\n" +
+                "          \"operator\": \"LT\",\n" +
+                "          \"threshold\": 10.0,\n" +
+                "          \"context\": {\n" +
+                "            \"description\": \"Response Time\",\n" +
+                "            \"unit\": \"ms\"\n" +
+                "          }\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }";
+
+        // remove if it exists
+        def resp = client.delete(path: "triggers/full-test-trigger-1")
+        assert(200 == resp.status || 404 == resp.status)
+
+        // create the test trigger
+        resp = client.post(path: "triggers/trigger", body: jsonTrigger)
+        assertEquals(400, resp.status)
+
+        jsonTrigger = "{\n" +
+                "      \"trigger\":{\n" +
+                "        \"id\": \"full-test-trigger-1\",\n" +
+                "        \"enabled\": true,\n" +
+                "        \"name\": \"NumericData-01-low\",\n" +
+                "        \"description\": \"description 1\",\n" +
+                "        \"severity\": \"HIGH\",\n" +
+                "        \"actions\": [\n" +
+                // Unknown plugin
+                "          {\"actionPlugin\":\"unknown\", \"actionId\":\"email-to-nothing\"}\n" +
+                "        ],\n" +
+                "        \"context\": {\n" +
+                "          \"name1\":\"value1\"\n" +
+                "        },\n" +
+                "        \"tags\": {\n" +
+                "          \"tname1\":\"tvalue1\",\n" +
+                "          \"tname2\":\"tvalue2\"\n" +
+                "        }\n" +
+                "      },\n" +
+                "      \"dampenings\":[\n" +
+                "        {\n" +
+                "          \"triggerMode\": \"FIRING\",\n" +
+                "          \"type\": \"STRICT\",\n" +
+                "          \"evalTrueSetting\": 2,\n" +
+                "          \"evalTotalSetting\": 2\n" +
+                "        }\n" +
+                "      ],\n" +
+                "      \"conditions\":[\n" +
+                "        {\n" +
+                "          \"triggerMode\": \"FIRING\",\n" +
+                "          \"type\": \"threshold\",\n" +
+                "          \"dataId\": \"NumericData-01\",\n" +
+                "          \"operator\": \"LT\",\n" +
+                "          \"threshold\": 10.0,\n" +
+                "          \"context\": {\n" +
+                "            \"description\": \"Response Time\",\n" +
+                "            \"unit\": \"ms\"\n" +
+                "          }\n" +
+                "        }\n" +
+                "      ]\n" +
+                "    }";
+
+        // create the test trigger
+        resp = client.post(path: "triggers/trigger", body: jsonTrigger)
+        assertEquals(400, resp.status)
+    }
+
+    @Test
+    void validateMultipleTriggerModeConditions() {
+        Trigger testTrigger = new Trigger("test-multiple-mode-conditions", "No-Metric")
+
+        // make sure clean test trigger exists
+        client.delete(path: "triggers/test-multiple-mode-conditions")
+        def resp = client.post(path: "triggers", body: testTrigger)
+        assertEquals(200, resp.status)
+
+        ThresholdCondition testCond1 = new ThresholdCondition("test-multiple-mode-conditions", Mode.FIRING,
+                "No-Metric", ThresholdCondition.Operator.GT, 10.12);
+
+        ThresholdCondition testCond2 = new ThresholdCondition("test-multiple-mode-conditions", Mode.AUTORESOLVE,
+                "No-Metric", ThresholdCondition.Operator.LT, 4.10);
+
+        Collection<Condition> conditions = new ArrayList<>(2);
+        conditions.add( testCond1 );
+        conditions.add( testCond2 );
+        resp = client.put(path: "triggers/test-multiple-mode-conditions/conditions/firing", body: conditions)
+        assertEquals(400, resp.status)
+
+        resp = client.delete(path: "triggers/test-multiple-mode-conditions")
+        assertEquals(200, resp.status)
+    }
+
+    @Test
+    void validateMultipleTriggerModeConditionsInGroups() {
+        Trigger groupTrigger = new Trigger("group-trigger", "group-trigger");
+        groupTrigger.setEnabled(false);
+
+        // remove if it exists
+        def resp = client.delete(path: "triggers/groups/group-trigger", query: [keepNonOrphans:false,keepOrphans:false])
+        assert(200 == resp.status || 404 == resp.status)
+
+        // create the group
+        resp = client.post(path: "triggers/groups", body: groupTrigger)
+        assertEquals(200, resp.status)
+
+        resp = client.get(path: "triggers/group-trigger")
+        assertEquals(200, resp.status)
+        groupTrigger = (Trigger)resp.data;
+        assertEquals( true, groupTrigger.isGroup() );
+
+        ThresholdCondition cond1 = new ThresholdCondition("group-trigger", Mode.FIRING, "DataId1-Token",
+                ThresholdCondition.Operator.GT, 10.0);
+        ThresholdCondition cond2 = new ThresholdCondition("group-trigger", Mode.AUTORESOLVE, "DataId2-Token",
+                ThresholdCondition.Operator.LT, 20.0);
+
+        Map<String, Map<String, String>> dataIdMemberMap = new HashMap<>();
+        GroupConditionsInfo groupConditionsInfo = new GroupConditionsInfo(Arrays.asList(cond1, cond2), dataIdMemberMap)
+
+        resp = client.put(path: "triggers/groups/group-trigger/conditions/firing", body: groupConditionsInfo)
+        assertEquals(400, resp.status)
+
+        // remove group trigger
+        resp = client.delete(path: "triggers/groups/group-trigger")
+        assertEquals(200, resp.status)
+    }
+}

--- a/external/src/test/resources/application.properties
+++ b/external/src/test/resources/application.properties
@@ -1,0 +1,37 @@
+# Test configuration file. This disables Kafka requirements.
+
+# Http port
+quarkus.http.port=8083
+
+# == Inbound properties
+engine.receiver.store-events=true
+
+# == Infinispan properties
+engine.backend.ispn.reindex=false
+hawkular.data=target/hawkular.data
+
+# Used to clean triggers and data cache, defined in milliseconds
+engine.backend.ispn.partition-lifespan=100
+
+# == Drools properties
+engine.rules.events.duplicate-filter-time=0
+
+# Milliseconds
+engine.rules.data.duplicate-filter-time=1000
+
+# == Cache manager properties
+engine.cache.disable-publish-filtering=false
+engine.cache.reset-publish-cache=true
+
+# == Alerts Engine properties
+
+# Milliseconds
+engine.alerts.engine-delay=1000
+
+# Milliseconds
+engine.alerts.engine-period=2000
+
+# Defines if engine extensions are enabled and data is sent to them for processing
+engine.alerts.engine-extensions=false
+
+engine.data-driven-triggers-enabled=true

--- a/external/src/test/resources/application.properties
+++ b/external/src/test/resources/application.properties
@@ -1,5 +1,8 @@
 # Test configuration file. This disables Kafka requirements.
 
+#quarkus.log.level=TRACE
+#quarkus.log.category."org.hawkular".level=DEBUG
+
 # Http port
 quarkus.http.port=8083
 
@@ -26,10 +29,10 @@ engine.cache.reset-publish-cache=true
 # == Alerts Engine properties
 
 # Milliseconds
-engine.alerts.engine-delay=1000
+engine.alerts.engine-delay=100
 
 # Milliseconds
-engine.alerts.engine-period=2000
+engine.alerts.engine-period=200
 
 # Defines if engine extensions are enabled and data is sent to them for processing
 engine.alerts.engine-extensions=false

--- a/external/src/test/resources/import/alerts-data.json
+++ b/external/src/test/resources/import/alerts-data.json
@@ -1,0 +1,302 @@
+{
+  "triggers":[
+    {
+      "trigger":{
+        "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
+        "id": "trigger-1",
+        "enabled": true,
+        "name": "NumericData-01-low",
+        "description": "description 1",
+        "severity": "HIGH",
+        "actions": [
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
+        ],
+        "context": {
+          "name1":"value1"
+        },
+        "tags": {
+          "tname1":"tvalue1",
+          "tname2":"tvalue2"
+        }
+      },
+      "dampenings":[
+        {
+          "triggerMode": "FIRING",
+          "type": "STRICT",
+          "evalTrueSetting": 2,
+          "evalTotalSetting": 2
+        }
+      ],
+      "conditions":[
+        {
+          "triggerMode": "FIRING",
+          "type": "threshold",
+          "dataId": "NumericData-01",
+          "operator": "LT",
+          "threshold": 10.0,
+          "context": {
+            "description": "Response Time",
+            "unit": "ms"
+          }
+        }
+      ]
+    },
+    {
+      "trigger":{
+        "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
+        "id": "trigger-2",
+        "enabled": true,
+        "name": "NumericData-01-02-high",
+        "description": "description 2",
+        "severity": "HIGH",
+        "actions": [
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
+        ]
+      },
+      "dampenings":[],
+      "conditions":[
+        {
+          "triggerMode": "FIRING",
+          "type": "threshold",
+          "dataId": "NumericData-01",
+          "operator": "GTE",
+          "threshold": 15.0,
+          "context": {
+            "description": "Response Time",
+            "unit": "ms"
+          }
+        },
+        {
+          "triggerMode": "FIRING",
+          "type": "threshold",
+          "dataId": "NumericData-02",
+          "operator": "GTE",
+          "threshold": 15.0,
+          "context": {
+            "description": "Response Time",
+            "unit": "ms"
+          }
+        }
+      ]
+    },
+    {
+      "trigger":{
+        "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
+        "id": "trigger-3",
+        "enabled": true,
+        "name": "NumericData-03-range",
+        "description": "description 3",
+        "severity": "HIGH",
+        "actions": [
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
+        ]
+      },
+      "dampenings":[],
+      "conditions":[
+        {
+          "triggerMode": "FIRING",
+          "type": "range",
+          "dataId": "NumericData-03",
+          "operatorLow": "INCLUSIVE",
+          "operatorHigh": "INCLUSIVE",
+          "thresholdLow": 10.0,
+          "thresholdHigh": 15.0,
+          "inRange": true,
+          "context": {
+            "description": "Response Time",
+            "unit": "ms"
+          }
+        }
+      ]
+    },
+    {
+      "trigger":{
+        "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
+        "id": "trigger-4",
+        "enabled": true,
+        "name": "CompareData-01-d1-lthalf-d2",
+        "description": "description 4",
+        "severity": "HIGH",
+        "actions": [
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
+        ]
+      },
+      "dampenings":[],
+      "conditions":[
+        {
+          "triggerMode": "FIRING",
+          "type": "compare",
+          "dataId": "NumericData-01",
+          "operator": "LT",
+          "data2Multiplier": 0.5,
+          "data2Id": "NumericData-02",
+          "context": {
+            "description": "Response Time",
+            "unit": "ms"
+          }
+        }
+      ]
+    },
+    {
+      "trigger":{
+        "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
+        "id": "trigger-5",
+        "enabled": true,
+        "name": "StringData-01-starts",
+        "description": "description 5",
+        "severity": "HIGH",
+        "actions": [
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
+        ]
+      },
+      "dampenings":[],
+      "conditions":[
+        {
+          "triggerMode": "FIRING",
+          "type": "string",
+          "dataId": "StringData-01",
+          "operator": "STARTS_WITH",
+          "pattern": "Fred",
+          "ignoreCase": false,
+          "context": {
+            "description": "Server Name"
+          }
+        }
+      ]
+    },
+    {
+      "trigger":{
+        "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
+        "id": "trigger-6",
+        "enabled": true,
+        "name": "Availability-01-NOT-UP",
+        "description": "description 6",
+        "severity": "HIGH",
+        "actions": [
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
+        ]
+      },
+      "dampenings":[],
+      "conditions":[
+        {
+          "triggerMode": "FIRING",
+          "type": "availability",
+          "dataId": "Availability-01",
+          "operator": "NOT_UP",
+          "context": {
+            "description": "Server"
+          }
+        }
+      ]
+    },
+    {
+      "trigger":{
+        "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
+        "id": "trigger-7",
+        "type": "GROUP",
+        "enabled": true,
+        "name": "Parent-NumericData-Token-low",
+        "description": "description 8",
+        "severity": "HIGH",
+        "actions": [
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
+        ]
+      },
+      "dampenings":[
+        {
+          "triggerMode": "FIRING",
+          "type": "RELAXED_COUNT",
+          "evalTrueSetting": 1,
+          "evalTotalSetting": 2
+        }
+      ],
+      "conditions":[
+        {
+          "triggerMode": "FIRING",
+          "type": "threshold",
+          "dataId": "NumericData-Token",
+          "operator": "LT",
+          "threshold": 10.0,
+          "context": {
+            "description": "Response Time",
+            "unit": "ms"
+          }
+        }
+      ]
+    },
+    {
+      "trigger":{
+        "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
+        "id": "trigger-8",
+        "eventType": "EVENT",
+        "enabled": true,
+        "name": "NumericData-01-low",
+        "description": "Event generating trigger",
+        "severity": "HIGH",
+        "actions": [
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
+        ],
+        "context": {
+          "trigger-8-name":"value"
+        },
+        "tags": {
+          "trigger8-name1":"value1",
+          "trigger8-name2":"value2"
+        }
+      },
+      "dampenings":[],
+      "conditions":[
+        {
+          "triggerMode": "FIRING",
+          "type": "threshold",
+          "dataId": "NumericData-01",
+          "operator": "LT",
+          "threshold": 10.0,
+          "context": {
+            "description": "Response Time",
+            "unit": "ms"
+          }
+        }
+      ]
+    },
+    {
+      "trigger":{
+        "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
+        "id": "trigger-9",
+        "enabled": true,
+        "name": "RateConditionTest",
+        "description": "Rate Condition Test",
+        "severity": "HIGH",
+        "actions": [
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
+        ]
+      },
+      "dampenings":[],
+      "conditions":[
+        {
+          "triggerMode": "FIRING",
+          "type": "rate",
+          "dataId": "SessionCount",
+          "direction": "INCREASING",
+          "period": "MINUTE",
+          "operator": "GT",
+          "threshold": 100.0,
+          "context": {
+            "description": "SessionCountPerMinute"
+          }
+        }
+      ]
+    }
+  ],
+  "actions":[
+    {
+      "tenantId": "28026b36-8fe4-4332-84c8-524e173a68bf",
+      "actionPlugin": "email",
+      "actionId": "email-to-admin",
+      "properties": {
+        "to": "admin@hawkular.org",
+        "cc": "bigboss@hawkular.org"
+      }
+    }
+  ]
+}

--- a/external/src/test/resources/import/groups-data.json
+++ b/external/src/test/resources/import/groups-data.json
@@ -1,0 +1,73 @@
+{
+  "triggers":[
+    {
+      "trigger":{
+        "id": "template-trigger",
+        "type": "GROUP",
+        "enabled": true,
+        "name": "Template Trigger",
+        "description": "Trigger definition used as parent",
+        "severity": "HIGH",
+        "actions": [
+          {"actionPlugin":"email", "actionId":"email-to-admin"}
+        ]
+      },
+      "conditions":[
+        {
+          "triggerMode": "FIRING",
+          "type": "threshold",
+          "dataId": "Generic-X",
+          "operator": "LT",
+          "threshold": 10.0,
+          "context": {
+            "description": "Response Time",
+            "unit": "ms"
+          }
+        },
+        {
+          "triggerMode": "FIRING",
+          "type": "threshold",
+          "dataId": "Generic-Y",
+          "operator": "GT",
+          "threshold": 200.0,
+          "context": {
+            "description": "Memory",
+            "unit": "mb"
+          }
+        }
+      ]
+    }
+  ],
+  "groupMembersInfo":[
+    {
+      "groupId": "template-trigger",
+      "memberId": "member1",
+      "memberName": "Member 1",
+      "memberDescription": "This is the first member",
+      "dataIdMap":{
+        "Generic-X": "Member1-X",
+        "Generic-Y": "Member1-Y"
+      }
+    },
+    {
+      "groupId": "template-trigger",
+      "memberId": "member2",
+      "memberName": "Member 2",
+      "memberDescription": "This is the second member",
+      "dataIdMap":{
+        "Generic-X": "Member2-X",
+        "Generic-Y": "Member2-Y"
+      }
+    }
+  ],
+  "actions":[
+    {
+      "actionPlugin": "email",
+      "actionId": "email-to-admin",
+      "properties": {
+        "to": "admin@hawkular.org",
+        "cc": "bigboss@hawkular.org"
+      }
+    }
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -24,12 +24,6 @@
     </license>
   </licenses>
 
-  <!--
-  API: jackson, junit
-  Commons: version.org.jboss.logging, version.org.infinispan.wildfly, version.org.jboss.logging.jboss-logging-tools, slf4j
-  Engine: version.org.drools, commons-math3 (Nelson vain), antlr (tags), jackson, version.org.infinispan.wildfly, version.org.apache.logging.log4j (test), junit
-  -->
-
   <properties>
     <!-- Maven related -->
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -37,7 +31,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <version.maven-patch-plugin>1.2</version.maven-patch-plugin>
-    <!-- Verify if necessary -->
     <version.org.apache.maven.plugins.maven-antrun-plugin>1.8</version.org.apache.maven.plugins.maven-antrun-plugin>
     <version.org.apache.maven.plugins.maven-failsafe-plugin>2.19.1</version.org.apache.maven.plugins.maven-failsafe-plugin>
     <version.org.apache.maven.plugins.maven-surefire-plugin>2.22.1</version.org.apache.maven.plugins.maven-surefire-plugin>
@@ -57,9 +50,10 @@
 
     <version.com.fasterxml.jackson>2.10.1</version.com.fasterxml.jackson>
 
-    <!-- Used for openapi docs and itests -->
+    <!-- Used for openapi generation and itests -->
     <version.org.codehaus.groovy>2.5.8</version.org.codehaus.groovy>
     <version.org.codehaus.gmavenplus>1.8.1</version.org.codehaus.gmavenplus>
+    <version.org.codehaus.groovy.modules.http-builder>0.7.1</version.org.codehaus.groovy.modules.http-builder>
 
     <!-- Wildfly to Quarkus related stuff to be ported / removed -->
     <version.org.hibernate>5.10.7.Final</version.org.hibernate>
@@ -68,7 +62,7 @@
     <version.org.jboss.logging.jboss-logging-tools>2.0.2.Final</version.org.jboss.logging.jboss-logging-tools>
 
     <!-- Quarkus -->
-    <quarkus.version>1.0.1.Final</quarkus.version>
+    <quarkus.version>1.1.0.Final</quarkus.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
When -Pitest is added, runs integration tests which have been ported from the Hawkular-Alerts (with some modifications if the functionality has changed in the custom-policies-engine). Targets the REST-interface only at this point. Not all of the integration tests will be ported as some of those don't make sense anymore.

Also, adds -Pitest to the Github Actions, updates Quarkus to 1.1.0.Final and some smaller updates to maven files.