### PR TITLE
CPOL-29 Let Quarkus configure the logging implementation

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -12,10 +12,9 @@
   <artifactId>custom-policies-engine-commons</artifactId>
   <packaging>jar</packaging>
 
-  <name>Custom Policies Engine: Commons (deprecated)</name>
+  <name>Custom Policies Engine: Commons</name>
 
   <dependencies>
-
     <dependency>
       <groupId>org.infinispan</groupId>
       <artifactId>infinispan-core</artifactId>
@@ -23,10 +22,6 @@
       <version>${version.org.infinispan}</version>
     </dependency>
 
-    <dependency>
-      <groupId>org.jboss.logging</groupId>
-      <artifactId>jboss-logging</artifactId>
-    </dependency>
     <dependency>
       <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging-annotations</artifactId>
@@ -37,12 +32,5 @@
       <artifactId>jboss-logging-processor</artifactId>
       <version>${version.org.jboss.logging.jboss-logging-tools}</version>
     </dependency>
-
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${version.org.slf4j}</version>
-    </dependency>
-
   </dependencies>
 </project>

--- a/commons/src/main/java/org/hawkular/alerts/log/AlertingLogger.java
+++ b/commons/src/main/java/org/hawkular/alerts/log/AlertingLogger.java
@@ -7,11 +7,7 @@ import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.ValidIdRange;
 
-/**
- * @author Jay Shaughnessy
- * @author Lucas Ponce
- */
-@MessageLogger(projectCode = "HAWKALERT")
+@MessageLogger(projectCode = "CPOL")
 @ValidIdRange(min = 220000, max = 299999)
 public interface AlertingLogger extends MsgLogger {
 

--- a/commons/src/main/java/org/hawkular/commons/log/MsgLogger.java
+++ b/commons/src/main/java/org/hawkular/commons/log/MsgLogger.java
@@ -1,16 +1,8 @@
 package org.hawkular.commons.log;
 
-
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.MessageLogger;
 
-/**
- * Default Logger.
- * Each project can extend it with personalized messages.
- *
- * @author Jay Shaughnessy
- * @author Lucas Ponce
- */
-@MessageLogger(projectCode = "HAWKULAR")
+@MessageLogger(projectCode = "CPOL")
 public interface MsgLogger extends BasicLogger {
 }

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -15,7 +15,7 @@
 
   <dependencies>
 
-    <!-- Hawkular Alerting dependencies -->
+    <!-- Custom Policies dependencies -->
     <dependency>
       <groupId>com.redhat.cloud.custompolicies</groupId>
       <artifactId>custom-policies-engine-api</artifactId>
@@ -28,6 +28,7 @@
       <version>${project.version}</version>
     </dependency>
 
+    <!-- Drools / KIE -->
     <dependency>
       <groupId>org.kie</groupId>
       <artifactId>kie-api</artifactId>
@@ -38,6 +39,7 @@
       <scope>runtime</scope>
     </dependency>
 
+    <!-- Misc -->
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-math3</artifactId>
@@ -97,20 +99,6 @@
           <artifactId>hibernate-search-backend-elasticsearch</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
-      <scope>test</scope>
-      <version>${version.org.apache.logging.log4j}</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <scope>test</scope>
-      <version>${version.org.apache.logging.log4j}</version>
     </dependency>
 
     <!-- Tests -->

--- a/engine/src/main/resources/META-INF/kmodule.xml
+++ b/engine/src/main/resources/META-INF/kmodule.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<kmodule xmlns="http://jboss.org/kie/6.0.0/kmodule">
+<kmodule xmlns="http://www.drools.org/xsd/kmodule">
   <kbase name="customProfilesEngine" packages="org.hawkular.alerts.engine.rules" equalsBehavior="equality">
     <ksession name="customProfilesEngineSession"/>
   </kbase>

--- a/external/pom.xml
+++ b/external/pom.xml
@@ -14,21 +14,23 @@
   <properties>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <surefire-plugin.version>2.22.0</surefire-plugin.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <compiler-plugin.version>3.8.1</compiler-plugin.version>
     <maven.compiler.target>1.8</maven.compiler.target>
   </properties>
   <dependencies>
+    <!-- Project -->
+    <dependency>
+      <groupId>com.redhat.cloud.custompolicies</groupId>
+      <artifactId>custom-policies-engine-engine</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- Quarkus -->
     <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-resteasy</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
@@ -48,11 +50,6 @@
       <artifactId>quarkus-smallrye-reactive-messaging-kafka</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.redhat.cloud.custompolicies</groupId>
-      <artifactId>custom-policies-engine-engine</artifactId>
-      <version>${project.version}</version>
-    </dependency>
-    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-vertx</artifactId>
     </dependency>
@@ -60,7 +57,13 @@
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-vertx-web</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
 
+    <!-- Groovy Tests -->
     <dependency>
       <groupId>org.codehaus.groovy.modules.http-builder</groupId>
       <artifactId>http-builder</artifactId>
@@ -92,7 +95,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>${surefire-plugin.version}</version>
+        <version>${version.org.apache.maven.plugins.maven-surefire-plugin}</version>
         <configuration>
           <systemProperties>
             <java.util.logging.manager>org.jboss.logmanager.LogManager</java.util.logging.manager>
@@ -113,7 +116,7 @@
         <plugins>
           <plugin>
             <artifactId>maven-failsafe-plugin</artifactId>
-            <version>${surefire-plugin.version}</version>
+            <version>${version.org.apache.maven.plugins.maven-surefire-plugin}</version>
             <executions>
               <execution>
                 <goals>

--- a/external/src/main/java/com/redhat/cloud/custompolicies/engine/actions/QuarkusActionPluginRegister.java
+++ b/external/src/main/java/com/redhat/cloud/custompolicies/engine/actions/QuarkusActionPluginRegister.java
@@ -64,14 +64,9 @@ public class QuarkusActionPluginRegister {
     }
 
     public void init() {
-        log.infof("Scanning through available plugins");
         for (ActionPluginListener pluginListener : pluginListeners) {
-            log.infof("Found instance of: %s", pluginListener);
             Class<? extends ActionPluginListener> aClass = pluginListener.getClass();
             Plugin annotation = aClass.getAnnotation(Plugin.class);
-            if (annotation != null) {
-                log.infof("Direct call would result in: %s", annotation.name());
-            }
             for (Annotation declaredAnnotation : pluginListener.getClass().getDeclaredAnnotations()) {
                 if(declaredAnnotation instanceof Plugin) {
                     Plugin pluginAnnotation = (Plugin) declaredAnnotation;

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <version.maven-patch-plugin>1.2</version.maven-patch-plugin>
     <version.org.apache.maven.plugins.maven-antrun-plugin>1.8</version.org.apache.maven.plugins.maven-antrun-plugin>
     <version.org.apache.maven.plugins.maven-failsafe-plugin>2.22.1</version.org.apache.maven.plugins.maven-failsafe-plugin>
     <version.org.apache.maven.plugins.maven-surefire-plugin>2.22.1</version.org.apache.maven.plugins.maven-surefire-plugin>
@@ -38,19 +37,13 @@
     <version.org.apache.maven.plugins.maven-resources-plugin>3.0.2</version.org.apache.maven.plugins.maven-resources-plugin>
 
     <!-- Rest of them -->
-    <version.junit>4.12</version.junit> <!-- Quarkus module uses JUnit 5 -->
+    <version.junit>4.12</version.junit> <!-- External module uses Quarkus' JUnit 5 -->
     <version.org.antlr>4.7.2</version.org.antlr>
     <version.org.apache.commons.commons-math3>3.4.1</version.org.apache.commons.commons-math3>
     <version.org.drools>7.31.0.Final</version.org.drools>
     <version.com.google.guava>28.1-jre</version.com.google.guava>
-    <distribution.name>hawkular-alerting</distribution.name>
 
     <version.com.fasterxml.jackson>2.10.1</version.com.fasterxml.jackson>
-
-    <!-- Logging related mess -->
-    <version.log4j>1.2.17</version.log4j>
-    <version.org.slf4j>1.7.2</version.org.slf4j>
-    <version.org.apache.logging.log4j>2.8.1</version.org.apache.logging.log4j>
 
     <!-- Used for openapi generation and itests -->
     <version.org.codehaus.groovy>2.5.8</version.org.codehaus.groovy>
@@ -60,7 +53,6 @@
     <!-- Wildfly to Quarkus related stuff to be ported / removed -->
     <version.org.hibernate>5.10.7.Final</version.org.hibernate>
     <version.org.infinispan>10.0.1.Final</version.org.infinispan>
-    <version.org.jboss.logging>3.4.1.Final</version.org.jboss.logging>
     <version.org.jboss.logging.jboss-logging-tools>2.2.1.Final</version.org.jboss.logging.jboss-logging-tools>
 
     <!-- Quarkus -->


### PR DESCRIPTION
Remove all logging implementations from the project, leaving only the jboss-logging for the log message generation.