### PR TITLE
Add counters for incoming/outgoing messages.

### DIFF
--- a/external/src/main/java/com/redhat/cloud/custompolicies/engine/actions/plugins/BetaHooksActionPluginRegister.java
+++ b/external/src/main/java/com/redhat/cloud/custompolicies/engine/actions/plugins/BetaHooksActionPluginRegister.java
@@ -8,6 +8,8 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.client.WebClientOptions;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.hawkular.alerts.actions.api.ActionMessage;
 import org.hawkular.alerts.actions.api.ActionPluginListener;
 import org.hawkular.alerts.actions.api.Plugin;
@@ -41,6 +43,11 @@ public class BetaHooksActionPluginRegister implements ActionPluginListener {
     @Inject
     @Channel("hooks")
     Emitter<JsonObject> channel;
+
+    @Inject
+    @Metric(absolute = true, name = "messages.outgoing.hook.count")
+    Counter messagesCount;
+
 
     private WebClient client;
 
@@ -102,6 +109,7 @@ public class BetaHooksActionPluginRegister implements ActionPluginListener {
         message.put("message", JsonObject.mapFrom(msg.getAction()));
         message.put("account_id", msg.getAction().getTenantId());
         channel.send(message);
+        messagesCount.inc();
     }
 
     @Override

--- a/external/src/main/java/com/redhat/cloud/custompolicies/engine/actions/plugins/EmailActionPluginListener.java
+++ b/external/src/main/java/com/redhat/cloud/custompolicies/engine/actions/plugins/EmailActionPluginListener.java
@@ -4,6 +4,8 @@ import com.redhat.cloud.custompolicies.engine.process.Receiver;
 import io.smallrye.reactive.messaging.annotations.Channel;
 import io.smallrye.reactive.messaging.annotations.Emitter;
 import io.vertx.core.json.JsonObject;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.hawkular.alerts.actions.api.ActionMessage;
 import org.hawkular.alerts.actions.api.ActionPluginListener;
 import org.hawkular.alerts.actions.api.Plugin;
@@ -29,6 +31,11 @@ public class EmailActionPluginListener implements ActionPluginListener {
     @Inject
     @Channel("email")
     Emitter<JsonObject> channel;
+
+    @Inject
+    @Metric(absolute = true, name = "messages.outgoing.email.count")
+    Counter messagesCount;
+
 
     public EmailActionPluginListener() {
         notifyBuffer = new ConcurrentSkipListMap<>();
@@ -76,6 +83,7 @@ public class EmailActionPluginListener implements ActionPluginListener {
             }
             Notification notification = notificationEntry.getValue();
             channel.send(JsonObject.mapFrom(notification));
+            messagesCount.inc();
         }
     }
 

--- a/external/src/main/java/com/redhat/cloud/custompolicies/engine/actions/plugins/WebhookActionPluginListener.java
+++ b/external/src/main/java/com/redhat/cloud/custompolicies/engine/actions/plugins/WebhookActionPluginListener.java
@@ -3,6 +3,8 @@ package com.redhat.cloud.custompolicies.engine.actions.plugins;
 import io.smallrye.reactive.messaging.annotations.Channel;
 import io.smallrye.reactive.messaging.annotations.Emitter;
 import io.vertx.core.json.JsonObject;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.hawkular.alerts.actions.api.ActionMessage;
 import org.hawkular.alerts.actions.api.ActionPluginListener;
 import org.hawkular.alerts.actions.api.Plugin;
@@ -23,9 +25,14 @@ public class WebhookActionPluginListener implements ActionPluginListener {
     @Channel("webhook")
     Emitter<JsonObject> channel;
 
+    @Inject
+    @Metric(absolute = true, name = "messages.outgoing.webhook.count")
+    Counter messagesCount;
+
     @Override
     public void process(ActionMessage actionMessage) throws Exception {
         Action action = actionMessage.getAction();
+        messagesCount.inc();
         channel.send(JsonObject.mapFrom(action));
     }
 

--- a/external/src/main/java/com/redhat/cloud/custompolicies/engine/process/Receiver.java
+++ b/external/src/main/java/com/redhat/cloud/custompolicies/engine/process/Receiver.java
@@ -3,6 +3,8 @@ package com.redhat.cloud.custompolicies.engine.process;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.eclipse.microprofile.metrics.Counter;
+import org.eclipse.microprofile.metrics.annotation.Metric;
 import org.eclipse.microprofile.reactive.messaging.Acknowledgment;
 import org.eclipse.microprofile.reactive.messaging.Incoming;
 import org.eclipse.microprofile.reactive.messaging.Message;
@@ -43,10 +45,15 @@ public class Receiver {
     @Inject
     AlertsService alertsService;
 
+    @Inject
+    @Metric(absolute = true, name = "messages.incoming.host-egress.count")
+    Counter incomingMessagesCount;
+
     @Incoming("kafka-hosts")
     @Acknowledgment(Acknowledgment.Strategy.MANUAL)
     public CompletionStage<Void> processAsync(Message<JsonObject> input) {
         return CompletableFuture.supplyAsync(() -> {
+            incomingMessagesCount.inc();
             JsonObject payload = input.getPayload();
             log.tracef("Received message, input payload: %s", payload);
             return payload;


### PR DESCRIPTION
```
snert:custom-policies-engine hrupp$ curl localhost:8084/metrics/application
# TYPE application_messages_outgoing_hook_count_total counter
application_messages_outgoing_hook_count_total 0.0
# TYPE application_messages_outgoing_email_count_total counter
application_messages_outgoing_email_count_total 0.0
# TYPE application_messages_incoming_host_egress_count_total counter
application_messages_incoming_host_egress_count_total 176.0
# TYPE application_messages_outgoing_webhook_count_total counter
application_messages_outgoing_webhook_count_total 0.0

```


Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>