### PR TITLE
CPOL-131 FullTriggerUpdate changes

### DIFF
--- a/engine/src/test/java/org/hawkular/alerts/engine/impl/ispn/IspnDefinitionsServiceImplTest.java
+++ b/engine/src/test/java/org/hawkular/alerts/engine/impl/ispn/IspnDefinitionsServiceImplTest.java
@@ -376,8 +376,17 @@ public class IspnDefinitionsServiceImplTest extends IspnBaseServiceImplTest {
         String actionId2 = fullTrigger.getTrigger().getActions().iterator().next().getActionId();
         assertEquals(actionId, actionId2);
 
+        // Test updating with original data - ensure that the managed id is really recreated
+        for (TriggerAction triggerAction : fullTrigger.getTrigger().getActions()) {
+            triggerAction.setActionId(null);
+        }
+        definitions.updateFullTrigger(TENANT, fullTrigger);
+        assertEquals(actionId, fullTrigger.getTrigger().getActions().iterator().next().getActionId());
+
         definitions.removeTrigger(TENANT, "trigger1");
         definitions.removeTrigger(TENANT, "trigger2");
+        definitions.removeActionDefinition(TENANT, "pluginM", actionId);
+        definitions.removeActionPlugin("pluginM");
     }
 
 }

--- a/external/src/main/java/com/redhat/cloud/custompolicies/engine/handlers/TriggersHandler.java
+++ b/external/src/main/java/com/redhat/cloud/custompolicies/engine/handlers/TriggersHandler.java
@@ -300,7 +300,7 @@ public class TriggersHandler {
                             definitionsService.updateFullTrigger(tenantId, fullTrigger);
                         }
                         log.debugf("FullTrigger: %s", fullTrigger);
-                        future.complete();
+                        future.complete(fullTrigger);
                     } catch (NotFoundException e) {
                         throw new NotFoundException(e.getMessage());
                     } catch (IllegalArgumentException e) {

--- a/external/src/test/groovy/org/hawkular/alerts/rest/TriggersITest.groovy
+++ b/external/src/test/groovy/org/hawkular/alerts/rest/TriggersITest.groovy
@@ -623,6 +623,14 @@ class TriggersITest extends AbstractQuarkusITestBase {
 
         assertEquals(actionId, actionId2)
 
+        def fullTrigger = resp.data
+        fullTrigger.trigger.actions[0].actionId = null
+        // Update and verify equality
+        resp = client.put(path: "triggers/trigger/full-test-trigger-1", body: fullTrigger)
+        assertEquals(200, resp.status)
+        assertTrue(resp.data.trigger.actions[0].actionId.startsWith("_managed"))
+        assertEquals(actionId, resp.data.trigger.actions[0].actionId)
+
         resp = client.delete(path: "triggers/full-test-trigger-1")
         assertEquals(200, resp.status)
 
@@ -785,6 +793,14 @@ class TriggersITest extends AbstractQuarkusITestBase {
         // try an update with no changes (should succeed but not actually perform any updates, need to manually verify)
         resp = client.put(path: "triggers/trigger/full-test-trigger-1", body: fullTrigger)
         assertEquals(200, resp.status)
+
+        // Try to update with null actionId
+        def prevActionId = trigger.actions.get(0).actionId
+        trigger.actions.get(0).actionId = null
+        resp = client.put(path: "triggers/trigger/full-test-trigger-1", body: fullTrigger)
+        // No managed id was created in previous section as the id was defined in the create, thus update will fail
+        assertEquals(400, resp.status)
+        trigger.actions.get(0).actionId = prevActionId
 
         // re-get the test trigger
         def prevFullTrigger = fullTrigger;


### PR DESCRIPTION
Return updated value after PUT and accept managed plugin updates without actionId (if previously one has been created with POST). 

If actionId is incorrect (missing or not found), reject with code 400.